### PR TITLE
#467: move maxDepth to Labyrinth

### DIFF
--- a/Classes/Labyrinth.js
+++ b/Classes/Labyrinth.js
@@ -2,15 +2,16 @@ module.exports = class Labyrinth {
 	/**
 	 * @param {string} nameInput
 	 * @param {"Fire" | "Water" | "Earth" | "Wind" | "Untyped"} elementInput
+	 * @param {number} maxDepthInput integer
 	 */
-	constructor(nameInput, elementInput) {
+	constructor(nameInput, elementInput, maxDepthInput) {
 		this.name = nameInput;
 		this.element = elementInput;
+		this.maxDepth = maxDepthInput;
 	}
 	availableConsumables = []; //TODO #465 merge consumable changes into base labyrinth
 	availableEquipment = []; //TODO #464 merge equipment changes into base labyrinth
 	// avaialableRooms = []; //TODO #466 add rooms to Labyrinth
-	// maxDepth = 10; //TODO #467 move maxDepth to Labyrinth
 	// bossRoomDepths = []; //TODO #468 move bossRoomDepths to Labyrinth
 
 	/**

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -207,7 +207,7 @@ exports.nextRoom = async function (roomType, thread) {
 					.setUIGroup("scouting");
 			}
 		}
-		if (adventure.depth < 10) {
+		if (adventure.depth < adventure.labyrinth.maxDepth) {
 			let roomMessage = await thread.send({
 				embeds: [embed.addField("Decide the next room", "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous.")],
 				components: [...roomTemplate.uiRows, ...generateMerchantRows(adventure), generateRoutingRow(adventure)]
@@ -434,7 +434,7 @@ exports.endRound = async function (adventure, thread) {
 			// Finalize UI
 			embed = embed.setTitle("Victory!").setDescription(lastRoundText)
 				.setColor(getColor(adventure.room.element));
-			if (adventure.depth < 10) {
+			if (adventure.depth < adventure.labyrinth.maxDepth) {
 				return thread.send({
 					embeds: [embed.addField("Decide the next room", "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous.")],
 					components: [generateLootRow(adventure), generateRoutingRow(adventure)]

--- a/Source/labyrinths/debugdungeon.js
+++ b/Source/labyrinths/debugdungeon.js
@@ -1,6 +1,6 @@
 const Labyrinth = require("../../Classes/Labyrinth");
 
-module.exports = new Labyrinth("Debug Dungeon", "Untyped")
+module.exports = new Labyrinth("Debug Dungeon", "Untyped", 10)
 	.setConsumables(
 		{
 			Earth: [],


### PR DESCRIPTION
Creates `maxDepth` property on Labyrinth, to allow varying lengths in labyrinths. Also replaces previously hard-coded maxDepth of 10 with value fetched from current Labyrinth.

Cases tested locally:
- bot turns on

Closes #467