### PR TITLE
#476: document move speed setters

### DIFF
--- a/Classes/Move.js
+++ b/Classes/Move.js
@@ -1,4 +1,6 @@
-const { calculateTotalSpeed, removeModifier } = require("../Source/combatantDAO");
+const { calculateTotalSpeed: calculateTotalSpeed, removeModifier } = require("../Source/combatantDAO");
+const Delver = require("./Delver");
+const Enemy = require("./Enemy");
 
 module.exports = class Move {
 	constructor() {
@@ -25,7 +27,11 @@ module.exports = class Move {
 		return this;
 	}
 
-	calculateMoveSpeed(combatant) {
+	/** In addition to containing logic for enemy speed mechanics, this function also consumes a stack of Quicken and Slow
+	 * @param {Delver | Enemy} combatant
+	 * @returns {Move}
+	 */
+	onSetMoveSpeed(combatant) {
 		this.speed = calculateTotalSpeed(combatant);
 		removeModifier(combatant, { name: "Slow", stacks: 1, force: true });
 		removeModifier(combatant, { name: "Quicken", stacks: 1, force: true });

--- a/Source/Buttons/confirmmove.js
+++ b/Source/Buttons/confirmmove.js
@@ -15,7 +15,7 @@ module.exports = new Button(id, async (interaction, [moveName, round, index]) =>
 			// Add move to round list (overwrite exisiting readied move)
 			let userIndex = adventure.delvers.findIndex(delver => delver.id === interaction.user.id);
 			let newMove = new Move()
-				.calculateMoveSpeed(user)
+				.onSetMoveSpeed(user)
 				.setIsCrit(user.crit)
 				.setMoveName(moveName)
 				.setType("equip")

--- a/Source/Selects/consumable.js
+++ b/Source/Selects/consumable.js
@@ -15,7 +15,7 @@ module.exports = new Select(id, async (interaction, [round]) => {
 			const user = adventure.delvers.find(delver => delver.id === interaction.user.id);
 			let userIndex = adventure.delvers.findIndex(delver => delver.id === interaction.user.id);
 			let newMove = new Move()
-				.calculateMoveSpeed(user)
+				.onSetMoveSpeed(user)
 				.setIsCrit(false)
 				.setMoveName(consumableName)
 				.setType("consumable")

--- a/Source/Selects/movetarget.js
+++ b/Source/Selects/movetarget.js
@@ -16,7 +16,7 @@ module.exports = new Select(id, async (interaction, [moveName, round, index]) =>
 			let userIndex = adventure.delvers.findIndex(delver => delver.id === interaction.user.id);
 			let [targetTeam, targetIndex] = interaction.values[0].split(SAFE_DELIMITER);
 			let newMove = new Move()
-				.calculateMoveSpeed(user)
+				.onSetMoveSpeed(user)
 				.setIsCrit(user.crit)
 				.setMoveName(moveName)
 				.setType(moveName === "Punch" ? "action" : "equip")

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -277,7 +277,7 @@ exports.newRound = function (adventure, thread, embed = new MessageEmbed()) {
 			// Roll Enemy Moves and Generate Dummy Moves
 			let move = new Move()
 				.setType("action")
-				.calculateMoveSpeed(combatant)
+				.onSetMoveSpeed(combatant)
 				.setIsCrit(combatant.crit)
 				.setUser(teamName, i)
 			if (combatant.getModifierStacks("Stun") > 0) {
@@ -359,7 +359,7 @@ exports.endRound = async function (adventure, thread) {
 		if (enemy.lookupName === "@{clone}") {
 			let move = new Move()
 				.setType("action")
-				.calculateMoveSpeed(enemy)
+				.onSetMoveSpeed(enemy)
 				.setIsCrit(enemy.crit)
 			let counterpartHasPriority = false;
 			let counterpartMove = adventure.room.moves.find(move => move.userTeam === "delver" && move.userIndex == index);

--- a/Source/combatantDAO.js
+++ b/Source/combatantDAO.js
@@ -15,6 +15,10 @@ exports.getFullName = function (combatant, titleObject) {
 	}
 }
 
+/** Speed is affected by `roundSpeed` and modifiers
+ * @param {Delver | Enemy} combatant
+ * @returns {number}
+ */
 exports.calculateTotalSpeed = function (combatant) {
 	let totalSpeed = combatant.speed + combatant.roundSpeed;
 	if ("Slow" in combatant.modifiers) {


### PR DESCRIPTION
Instead of refactoring the move speed handlers to a pure setter, this PR documents the existing architecture. A pure setter was deemed to cause too much code duplication, as the prior mentioned responsibilities would have to be re-implemented in 5 different places currently.

The function `Move.calculateMoveSpeed()` has been renamed to `Move.onSetMoveSpeed()` to expand its responsibility to include housing the logic for enemy speed mechanics and the consumption of Quicken/Slow stacks.

Cases tested locally:
- none (code changes were all documentation)

Closes #476