### PR TITLE
#446: fix zero count equipment loot option

### DIFF
--- a/Source/roomDAO.js
+++ b/Source/roomDAO.js
@@ -29,22 +29,24 @@ exports.generateLootRow = function (adventure) {
 	for (const resource of Object.values(adventure.room.resources)) {
 		if (resource.uiType === "loot") {
 			const { name, resourceType: type, count } = resource;
-			let option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
+			if (count > 0) {
+				let option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
 
-			if (name == "gold") {
-				option.label = `${count} Gold`;
-			} else {
-				option.label = `${name} x ${count}`;
-			}
+				if (name == "gold") {
+					option.label = `${count} Gold`;
+				} else {
+					option.label = `${name} x ${count}`;
+				}
 
-			if (type === "equipment") {
-				option.description = buildEquipmentDescription(name, false);
-			} else if (type === "artifact") {
-				option.description = getArtifact(name).dynamicDescription(count);
-			} else {
-				option.description = "";
+				if (type === "equipment") {
+					option.description = buildEquipmentDescription(name, false);
+				} else if (type === "artifact") {
+					option.description = getArtifact(name).dynamicDescription(count);
+				} else {
+					option.description = "";
+				}
+				options.push(option)
 			}
-			options.push(option)
 		}
 	}
 	if (options.length > 0) {


### PR DESCRIPTION
Summary
-------
Filters out loot that has zero count to prevent ghost equipment pickup options.

Local Tests Performed
---------------------
- does taking the last copy of an equipment remove it from the loot list?

Issue
-----
Closes #446