### PR TITLE
#468: add bossRoomDepths to Labyrinth

### DIFF
--- a/Classes/Labyrinth.js
+++ b/Classes/Labyrinth.js
@@ -3,16 +3,17 @@ module.exports = class Labyrinth {
 	 * @param {string} nameInput
 	 * @param {"Fire" | "Water" | "Earth" | "Wind" | "Untyped"} elementInput
 	 * @param {number} maxDepthInput integer
+	 * @param {Array<number>} bossRoomDepthsInput
 	 */
-	constructor(nameInput, elementInput, maxDepthInput) {
+	constructor(nameInput, elementInput, maxDepthInput, bossRoomDepthsInput) {
 		this.name = nameInput;
 		this.element = elementInput;
 		this.maxDepth = maxDepthInput;
+		this.bossRoomDepths = bossRoomDepthsInput;
 	}
 	availableConsumables = []; //TODO #465 merge consumable changes into base labyrinth
 	availableEquipment = []; //TODO #464 merge equipment changes into base labyrinth
 	// avaialableRooms = []; //TODO #466 add rooms to Labyrinth
-	// bossRoomDepths = []; //TODO #468 move bossRoomDepths to Labyrinth
 
 	/**
 	 * @param {object} consumables

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -110,14 +110,13 @@ exports.updateRoomHeader = function (adventure, message) {
 exports.nextRoom = async function (roomType, thread) {
 	let adventure = exports.getAdventure(thread.id);
 	// Roll options for next room type
-	let roomTypes = ["Battle", "Event", "Forge", "Rest Site", "Artifact Guardian", "Merchant"]; //TODO #126 add weights to room types
-	let finalBossDepths = [10];
-	if (!finalBossDepths.includes(adventure.depth + 1)) {
-		let mapCount = adventure.getArtifactCount("Enchanted Map");
-		let numCandidates = 2 + mapCount;
+	const roomTypes = ["Battle", "Event", "Forge", "Rest Site", "Artifact Guardian", "Merchant"]; //TODO #126 add weights to room types
+	if (!getLabyrinthProperty(adventure.labyrinth, "bossRoomDepths").includes(adventure.depth + 1)) {
+		const mapCount = adventure.getArtifactCount("Enchanted Map");
 		if (mapCount) {
 			adventure.updateArtifactStat("Enchanted Map", "Extra Rooms Rolled", mapCount);
 		}
+		const numCandidates = 2 + mapCount;
 		for (let i = 0; i < numCandidates; i++) {
 			const candidateTag = `${roomTypes[generateRandomNumber(adventure, roomTypes.length, "general")]}${SAFE_DELIMITER}${adventure.depth}`;
 			if (!(candidateTag in adventure.roomCandidates)) {

--- a/Source/labyrinths/debugdungeon.js
+++ b/Source/labyrinths/debugdungeon.js
@@ -1,6 +1,6 @@
 const Labyrinth = require("../../Classes/Labyrinth");
 
-module.exports = new Labyrinth("Debug Dungeon", "Untyped", 10)
+module.exports = new Labyrinth("Debug Dungeon", "Untyped", 10, [10])
 	.setConsumables(
 		{
 			Earth: [],


### PR DESCRIPTION
Summary
-------
Support varying location and count of boss rooms in different labyrinths with new property.

Also extended updateRoomHeader to update all embed headers instead of only the first in the message.

Local Tests Performed
---------------------
- confirmed boss depths are read properly from the labyrinth
- confirmed updateRoomHeader still works

Issue
-----
Closes #468