### PR TITLE
#504: fix HP Share button to use display name

### DIFF
--- a/Source/Buttons/hpshare.js
+++ b/Source/Buttons/hpshare.js
@@ -22,7 +22,7 @@ module.exports = new Button(id, (interaction, args) => {
 					interaction.update({ components: [] });
 					interaction.channel.send(completeAdventure(adventure, interaction.channel, resultText));
 				} else {
-					interaction.update({ components: editButtons(interaction.message.components, { [id]: { preventUse: true, label: `${interaction.user} shared HP.`, emoji: "✔️" } }) });
+					interaction.update({ components: editButtons(interaction.message.components, { [id]: { preventUse: true, label: `${interaction.member.displayName} shared HP.`, emoji: "✔️" } }) });
 					interaction.channel.send(resultText);
 					setAdventure(adventure);
 				}


### PR DESCRIPTION
Summary
-------
- fix HP Share button to use display name instead of mention

Local Tests Performed
---------------------
- used the button in the room

Issue
-----
Closes #504