### PR TITLE
#514: split crit bonus text out of equipment descriptions

### DIFF
--- a/Classes/EquipmentTemplate.js
+++ b/Classes/EquipmentTemplate.js
@@ -2,13 +2,15 @@ module.exports = class EquipmentTemplate {
 	/** This read-only data class defines stats for a piece of equipment
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
+	 * @param {string} critDescriptionInput
 	 * @param {"Fire" | "Water" | "Earth" | "Wind" | "Untyped"} elementInput
 	 * @param {Function} effectInput
 	 * @param {Array<string>} upgradeNames
 	 */
-	constructor(nameInput, descriptionInput, elementInput, effectInput, upgradeNames) {
+	constructor(nameInput, descriptionInput, critDescriptionInput, elementInput, effectInput, upgradeNames) {
 		this.name = nameInput;
 		this.description = descriptionInput;
+		this.critDescription = critDescriptionInput;
 		this.element = elementInput;
 		this.effect = effectInput;
 		this.upgrades = upgradeNames;

--- a/Source/Modifiers/poison.js
+++ b/Source/Modifiers/poison.js
@@ -1,7 +1,7 @@
 const Modifier = require("../../Classes/Modifier");
 
 module.exports = new Modifier("Poison", 1)
-	.setDescription("Deals @{funnelCount*@{stackCount*10}} unblockable damage after the sufferer's turn. Lose @{roundDecrement} stack per round.")
+	.setDescription("Deals @{stackCount*10} (+@{funnelCount*5} on enemies due to Spiral Funnels) unblockable damage after the sufferer's turn. Lose @{roundDecrement} stack per round.") //TODONOW shows as 0 damage?
 	.setIsBuff(false)
 	.setIsDebuff(true)
 	.setIsNonStacking(false)

--- a/Source/equipment/-punch.js
+++ b/Source/equipment/-punch.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Punch", "*Strike a foe for @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Untyped", effect, [])
+module.exports = new EquipmentTemplate("Punch", "Strike a foe for @{damage} @{element} damage", "Damage x@{critBonus}", "Untyped", effect, [])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([])

--- a/Source/equipment/_equipmentDictionary.js
+++ b/Source/equipment/_equipmentDictionary.js
@@ -121,7 +121,16 @@ exports.getEquipmentProperty = function (equipmentName, propertyName) {
 
 exports.buildEquipmentDescription = function (equipmentName, buildFullDescription) {
 	if (exports.equipmentExists(equipmentName)) {
-		let description = exports.getEquipmentProperty(equipmentName, "description").replace("@{element}", getEmoji(exports.getEquipmentProperty(equipmentName, "element")))
+		let description;
+		if (buildFullDescription) {
+			// return the base and crit effects of the equipment with the base italicized
+			description = `*Effect:* ${exports.getEquipmentProperty(equipmentName, "description")}\n*Critical💥:* ${exports.getEquipmentProperty(equipmentName, "critDescription")}`;
+		} else {
+			// return the base effect of the equipment unitalicized
+			description = exports.getEquipmentProperty(equipmentName, "description");
+		}
+
+		description = description.replace("@{element}", getEmoji(exports.getEquipmentProperty(equipmentName, "element")))
 			.replace("@{critBonus}", exports.getEquipmentProperty(equipmentName, "critBonus"))
 			.replace("@{damage}", exports.getEquipmentProperty(equipmentName, "damage"))
 			.replace("@{bonusDamage}", exports.getEquipmentProperty(equipmentName, "bonusDamage"))
@@ -132,13 +141,6 @@ exports.buildEquipmentDescription = function (equipmentName, buildFullDescriptio
 			description = description.replace(new RegExp(`@{mod${index}}`, "g"), modifier.name)
 				.replace(new RegExp(`@{mod${index}Stacks}`, "g"), modifier.stacks);
 		})
-
-		if (buildFullDescription) {
-			// return the base and crit effects of the equipment with the base italicized
-			return description;
-		} else {
-			// return the base effect of the equipment unitalicized
-			return description.split("\n")[0].replace(/\*/g, "");
-		}
+		return description;
 	}
 }

--- a/Source/equipment/barrier-base.js
+++ b/Source/equipment/barrier-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Barrier", "*Grant an ally @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Fire", effect, ["Purifiying Barrier", "Thick Barrier", "Urgent Barrier"])
+module.exports = new EquipmentTemplate("Barrier", "Grant an ally @{block} block", "Block x@{critBonus}", "Fire", effect, ["Purifiying Barrier", "Thick Barrier", "Urgent Barrier"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/barrier-purifying.js
+++ b/Source/equipment/barrier-purifying.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier, getFullName } = require('../combatantDAO.js');
 const { isDebuff } = require('../Modifiers/_modifierDictionary.js');
 
-module.exports = new EquipmentTemplate("Purifying Barrier", "*Grant an ally @{block} block and cure them of all debuffs*\nCritical Hit💥: Block x@{critBonus}", "Fire", effect, ["Thick Barrier", "Urgent Barrier"])
+module.exports = new EquipmentTemplate("Purifying Barrier", "Grant an ally @{block} block and cure them of all debuffs", "Block x@{critBonus}", "Fire", effect, ["Thick Barrier", "Urgent Barrier"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/barrier-thick.js
+++ b/Source/equipment/barrier-thick.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Thick Barrier", "*Grant an ally @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Fire", effect, ["Purifiying Barrier", "Urgent Barrier"])
+module.exports = new EquipmentTemplate("Thick Barrier", "Grant an ally @{block} block", "Block x@{critBonus}", "Fire", effect, ["Purifiying Barrier", "Urgent Barrier"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/barrier-urgent.js
+++ b/Source/equipment/barrier-urgent.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Urgent Barrier", "*Grant an ally @{block} block with priority*\nCritical Hit💥: Block x@{critBonus}", "Fire", effect, ["Purifiying Barrier", "Thick Barrier"])
+module.exports = new EquipmentTemplate("Urgent Barrier", "Grant an ally @{block} block with priority", "Block x@{critBonus}", "Fire", effect, ["Purifiying Barrier", "Thick Barrier"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/battleaxe-base.js
+++ b/Source/equipment/battleaxe-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Battleaxe", "*Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Thick Battleaxe", "Thirsting Battleaxe"])
+module.exports = new EquipmentTemplate("Battleaxe", "Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage", "Damage x@{critBonus}", "Fire", effect, ["Thick Battleaxe", "Thirsting Battleaxe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/battleaxe-prideful.js
+++ b/Source/equipment/battleaxe-prideful.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Prideful Battleaxe", "*Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Untyped", effect, ["Thick Battleaxe", "Thirsting Battleaxe"])
+module.exports = new EquipmentTemplate("Prideful Battleaxe", "Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage", "Damage x@{critBonus}", "Untyped", effect, ["Thick Battleaxe", "Thirsting Battleaxe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/battleaxe-thick.js
+++ b/Source/equipment/battleaxe-thick.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Thick Battleaxe", "*Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Prideful Battleaxe", "Thirsting Battleaxe"])
+module.exports = new EquipmentTemplate("Thick Battleaxe", "Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage", "Damage x@{critBonus}", "Fire", effect, ["Prideful Battleaxe", "Thirsting Battleaxe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/battleaxe-thirsting.js
+++ b/Source/equipment/battleaxe-thirsting.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, gainHealth, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Thirsting Battleaxe", "*Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage, gain @{healing} hp on kill*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Prideful Battleaxe", "Thick Battleaxe"])
+module.exports = new EquipmentTemplate("Thirsting Battleaxe", "Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage, gain @{healing} hp on kill", "Damage x@{critBonus}", "Fire", effect, ["Prideful Battleaxe", "Thick Battleaxe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/bloodaegis-base.js
+++ b/Source/equipment/bloodaegis-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { removeModifier, addBlock, dealDamage } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Blood Aegis", "*Pay @{hpCost} hp to grant an ally @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Charging Blood Aegis", "Heavy Blood Aegis", "Sweeping Blood Aegis"])
+module.exports = new EquipmentTemplate("Blood Aegis", "Pay @{hpCost} hp to grant an ally @{block} block", "Block x@{critBonus}", "Water", effect, ["Charging Blood Aegis", "Heavy Blood Aegis", "Sweeping Blood Aegis"])
 	.setCategory("Pact")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/bloodaegis-charging.js
+++ b/Source/equipment/bloodaegis-charging.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { removeModifier, addBlock, addModifier, dealDamage } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Charging Blood Aegis", "*Pay @{hpCost} hp to grant an ally @{block} block, then gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Heavy Blood Aegis", "Sweeping Blood Aegis"])
+module.exports = new EquipmentTemplate("Charging Blood Aegis", "Pay @{hpCost} hp to grant an ally @{block} block, then gain @{mod1Stacks} @{mod1}", "Block x@{critBonus}", "Water", effect, ["Heavy Blood Aegis", "Sweeping Blood Aegis"])
 	.setCategory("Pact")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }])

--- a/Source/equipment/bloodaegis-heavy.js
+++ b/Source/equipment/bloodaegis-heavy.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { removeModifier, addBlock, dealDamage } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Heavy Blood Aegis", "*Pay @{hpCost} hp to grant an ally @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Charging Blood Aegis", "Sweeping Blood Aegis"])
+module.exports = new EquipmentTemplate("Heavy Blood Aegis", "Pay @{hpCost} hp to grant an ally @{block} block", "Block x@{critBonus}", "Water", effect, ["Charging Blood Aegis", "Sweeping Blood Aegis"])
 	.setCategory("Pact")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/bloodaegis-sweeping.js
+++ b/Source/equipment/bloodaegis-sweeping.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { removeModifier, addBlock, dealDamage } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sweeping Blood Aegis", "*Pay @{hpCost} hp to grant all allies @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Charging Blood Aegis", "Heavy Blood Aegis"])
+module.exports = new EquipmentTemplate("Sweeping Blood Aegis", "Pay @{hpCost} hp to grant all allies @{block} block", "Block x@{critBonus}", "Water", effect, ["Charging Blood Aegis", "Heavy Blood Aegis"])
 	.setCategory("Pact")
 	.setTargetingTags({ target: "all", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/bow-base.js
+++ b/Source/equipment/bow-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Bow", "*Strike a foe for @{damage} @{element} damage with priority*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Evasive Bow", "Hunter's Bow", "Mercurial Bow"])
+module.exports = new EquipmentTemplate("Bow", "Strike a foe for @{damage} @{element} damage with priority", "Damage x@{critBonus}", "Wind", effect, ["Evasive Bow", "Hunter's Bow", "Mercurial Bow"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/bow-evasive.js
+++ b/Source/equipment/bow-evasive.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Evasive Bow", "*Strike a foe for @{damage} @{element} damage and gain @{mod1Stacks} @{mod1} with priority*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Hunter's Bow", "Mercurial Bow"])
+module.exports = new EquipmentTemplate("Evasive Bow", "Strike a foe for @{damage} @{element} damage and gain @{mod1Stacks} @{mod1} with priority", "Damage x@{critBonus}", "Wind", effect, ["Hunter's Bow", "Mercurial Bow"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }])

--- a/Source/equipment/bow-hunters.js
+++ b/Source/equipment/bow-hunters.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Hunter's Bow", "*Strike a foe for @{damage} @{element} damage with priority, gain @{bonusDamage}g on kill*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Evasive Bow", "Mercurial Bow"])
+module.exports = new EquipmentTemplate("Hunter's Bow", "Strike a foe for @{damage} @{element} damage with priority, gain @{bonusDamage}g on kill", "Damage x@{critBonus}", "Wind", effect, ["Evasive Bow", "Mercurial Bow"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/bow-mercurial.js
+++ b/Source/equipment/bow-mercurial.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Mercurial Bow", "*Strike a foe for @{damage} damage matching the user's element with priority*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Evasive Bow", "Hunter's Bow"])
+module.exports = new EquipmentTemplate("Mercurial Bow", "Strike a foe for @{damage} damage matching the user's element with priority", "Damage x@{critBonus}", "Wind", effect, ["Evasive Bow", "Hunter's Bow"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/buckler-base.js
+++ b/Source/equipment/buckler-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Buckler", "*Grant an ally @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Earth", effect, ["Guarding Buckler", "Heavy Buckler", "Urgent Buckler"])
+module.exports = new EquipmentTemplate("Buckler", "Grant an ally @{block} block", "Block x@{critBonus}", "Earth", effect, ["Guarding Buckler", "Heavy Buckler", "Urgent Buckler"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/buckler-guarding.js
+++ b/Source/equipment/buckler-guarding.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Guarding Buckler", "*Grant @{block} block to an ally and yourself*\nCritical Hit💥: Block x@{critBonus}", "Earth", effect, ["Heavy Buckler", "Urgent Buckler"])
+module.exports = new EquipmentTemplate("Guarding Buckler", "Grant @{block} block to an ally and yourself", "Block x@{critBonus}", "Earth", effect, ["Heavy Buckler", "Urgent Buckler"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/buckler-heavy.js
+++ b/Source/equipment/buckler-heavy.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Heavy Buckler", "*Grant an ally @{block} block*\nCritical Hit💥: Block x@{critBonus}", "Earth", effect, ["Guarding Buckler", "Urgent Buckler"])
+module.exports = new EquipmentTemplate("Heavy Buckler", "Grant an ally @{block} block", "Block x@{critBonus}", "Earth", effect, ["Guarding Buckler", "Urgent Buckler"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/buckler-urgent.js
+++ b/Source/equipment/buckler-urgent.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Urgent Buckler", "*Grant an ally @{block} block with priority*\nCritical Hit💥: Block x@{critBonus}", "Earth", effect, ["Guarding Buckler", "Heavy Buckler"])
+module.exports = new EquipmentTemplate("Urgent Buckler", "Grant an ally @{block} block with priority", "Block x@{critBonus}", "Earth", effect, ["Guarding Buckler", "Heavy Buckler"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/censer-base.js
+++ b/Source/equipment/censer-base.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 const { isDebuff } = require('../Modifiers/_modifierDictionary.js');
 
-module.exports = new EquipmentTemplate("Censer", "Burn a foe for @{damage} (+@{bonusDamage} if target has any debuffs) @{element} damage*\nCritical Hit💥: Also apply @{mod1Stacks} @{mod1}", "Fire", effect, ["Thick Censer", "Tormenting Censor"])
+module.exports = new EquipmentTemplate("Censer", "Burn a foe for @{damage} (+@{bonusDamage} if target has any debuffs) @{element} damage", "Also apply @{mod1Stacks} @{mod1}", "Fire", effect, ["Thick Censer", "Tormenting Censor"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/censer-thick.js
+++ b/Source/equipment/censer-thick.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 const { isDebuff } = require('../Modifiers/_modifierDictionary.js');
 
-module.exports = new EquipmentTemplate("Thick Censer", "Burn a foe for @{damage} (+@{bonusDamage} if target has any debuffs) @{element} damage*\nCritical Hit💥: Also apply @{mod1Stacks} @{mod1}", "Fire", effect, ["Tormenting Censor"])
+module.exports = new EquipmentTemplate("Thick Censer", "Burn a foe for @{damage} (+@{bonusDamage} if target has any debuffs) @{element} damage", "Also apply @{mod1Stacks} @{mod1}", "Fire", effect, ["Tormenting Censor"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/censer-tormenting.js
+++ b/Source/equipment/censer-tormenting.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Tormenting Censer", "Burn a foe for @{damage} (+@{bonusDamage} if target has any debuffs) @{element} damage and apply 1 stack of all their debuffs*\nCritical Hit💥: Also apply @{mod1Stacks} @{mod1}", "Fire", effect, ["Thick Censer"])
+module.exports = new EquipmentTemplate("Tormenting Censer", "Burn a foe for @{damage} (+@{bonusDamage} if target has any debuffs) @{element} damage and apply 1 stack of all their debuffs", "Also apply @{mod1Stacks} @{mod1}", "Fire", effect, ["Thick Censer"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/cloak-accelerating.js
+++ b/Source/equipment/cloak-accelerating.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Accelerating Cloak", "*Gain @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}*\nCritical Hit💥: Gain @{mod3Stacks} @{mod3} and @{mod4Stacks} @{mod4}", "Wind", effect, ["Long Cloak", "Thick Cloak"])
+module.exports = new EquipmentTemplate("Accelerating Cloak", "Gain @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}", "Instead gain @{mod3Stacks} @{mod3} and @{mod4Stacks} @{mod4}", "Wind", effect, ["Long Cloak", "Thick Cloak"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Quicken", stacks: 1 }, { name: "Evade", stacks: 3 }, { name: "Quicken", stacks: 2 }])

--- a/Source/equipment/cloak-base.js
+++ b/Source/equipment/cloak-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Cloak", "*Gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Gain @{mod2Stacks} @{mod2}", "Wind", effect, ["Accelerating Cloak", "Long Cloak", "Thick Cloak"])
+module.exports = new EquipmentTemplate("Cloak", "Gain @{mod1Stacks} @{mod1}", "Instead gain @{mod2Stacks} @{mod2}", "Wind", effect, ["Accelerating Cloak", "Long Cloak", "Thick Cloak"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Evade", stacks: 3 }])

--- a/Source/equipment/cloak-long.js
+++ b/Source/equipment/cloak-long.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Long Cloak", "*Gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Gain @{mod2Stacks} @{mod2}", "Wind", effect, ["Accelerating Cloak", "Thick Cloak"])
+module.exports = new EquipmentTemplate("Long Cloak", "Gain @{mod1Stacks} @{mod1}", "Instead gain @{mod2Stacks} @{mod2}", "Wind", effect, ["Accelerating Cloak", "Thick Cloak"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 3 }, { name: "Evade", stacks: 4 }])

--- a/Source/equipment/cloak-thick.js
+++ b/Source/equipment/cloak-thick.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Thick Cloak", "*Gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Gain @{mod2Stacks} @{mod2}", "Wind", effect, ["Accelerating Cloak", "Long Cloak"])
+module.exports = new EquipmentTemplate("Thick Cloak", "Gain @{mod1Stacks} @{mod1}", "Instead gain @{mod2Stacks} @{mod2}", "Wind", effect, ["Accelerating Cloak", "Long Cloak"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Evade", stacks: 3 }])

--- a/Source/equipment/corrosion-base.js
+++ b/Source/equipment/corrosion-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Corrosion", "*Inflict @{mod1Stacks} @{mod1} on a foe*\nCritical Hit💥: Inflict @{mod2Stacks} @{mod2} as well", "Fire", effect, ["Flanking Corrosion"])
+module.exports = new EquipmentTemplate("Corrosion", "Inflict @{mod1Stacks} @{mod1} on a foe", "Also inflict @{mod2Stacks} @{mod2}", "Fire", effect, ["Flanking Corrosion"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Down", stacks: 40 }, { name: "Stagger", stacks: 1 }])

--- a/Source/equipment/corrosion-flanking.js
+++ b/Source/equipment/corrosion-flanking.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Flanking Corrosion", "*Inflict @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} on a foe*\nCritical Hit💥: Inflict @{mod3Stacks} @{mod3} as well", "Fire", effect, [])
+module.exports = new EquipmentTemplate("Flanking Corrosion", "Inflict @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} on a foe", "Also inflict @{mod3Stacks} @{mod3}", "Fire", effect, [])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Down", stacks: 40 }, { name: "Exposed", stacks: 2 }, { name: "Stagger", stacks: 1 }])

--- a/Source/equipment/daggers-base.js
+++ b/Source/equipment/daggers-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Daggers", "*Strike a foe for @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Sharpened Daggers", "Sweeping Daggers", "Wicked Daggers"])
+module.exports = new EquipmentTemplate("Daggers", "Strike a foe for @{damage} @{element} damage", "Damage x@{critBonus}", "Wind", effect, ["Sharpened Daggers", "Sweeping Daggers", "Wicked Daggers"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/daggers-sharpened.js
+++ b/Source/equipment/daggers-sharpened.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Sharpened Daggers", "*Strike a foe for @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Sweeping Daggers", "Wicked Daggers"])
+module.exports = new EquipmentTemplate("Sharpened Daggers", "Strike a foe for @{damage} @{element} damage", "Damage x@{critBonus}", "Wind", effect, ["Sweeping Daggers", "Wicked Daggers"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/daggers-sweeping.js
+++ b/Source/equipment/daggers-sweeping.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sweeping Daggers", "*Strike all foes for @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Sharpened Daggers", "Wicked Daggers"])
+module.exports = new EquipmentTemplate("Sweeping Daggers", "Strike all foes for @{damage} @{element} damage", "Damage x@{critBonus}", "Wind", effect, ["Sharpened Daggers", "Wicked Daggers"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "all", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/daggers-wicked.js
+++ b/Source/equipment/daggers-wicked.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Wicked Daggers", "*Strike a foe for @{damage} (+@{bonusDamage} if foe has 0 block) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Wind", effect, ["Sharpened Daggers", "Sweeping Daggers"])
+module.exports = new EquipmentTemplate("Wicked Daggers", "Strike a foe for @{damage} (+@{bonusDamage} if foe has 0 block) @{element} damage", "Damage x@{critBonus}", "Wind", effect, ["Sharpened Daggers", "Sweeping Daggers"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/firecracker-base.js
+++ b/Source/equipment/firecracker-base.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier } = require('../combatantDAO.js');
 const { SAFE_DELIMITER } = require("../../constants.js");
 
-module.exports = new EquipmentTemplate("Firecracker", "*Strike 3 random foes for @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Double Firecracker", "Mercurial Firecracker", "Toxic Firecracker"])
+module.exports = new EquipmentTemplate("Firecracker", "Strike 3 random foes for @{damage} @{element} damage", "Damage x@{critBonus}", "Fire", effect, ["Double Firecracker", "Mercurial Firecracker", "Toxic Firecracker"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: `random${SAFE_DELIMITER}3`, team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/firecracker-double.js
+++ b/Source/equipment/firecracker-double.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier } = require('../combatantDAO.js');
 const { SAFE_DELIMITER } = require("../../constants.js");
 
-module.exports = new EquipmentTemplate("Double Firecracker", "*Strike 6 random foes for @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Mercurial Firecracker", "Toxic Firecracker"])
+module.exports = new EquipmentTemplate("Double Firecracker", "Strike 6 random foes for @{damage} @{element} damage", "Damage x@{critBonus}", "Fire", effect, ["Mercurial Firecracker", "Toxic Firecracker"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: `random${SAFE_DELIMITER}6`, team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/firecracker-mercurial.js
+++ b/Source/equipment/firecracker-mercurial.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier } = require('../combatantDAO.js');
 const { SAFE_DELIMITER } = require("../../constants.js");
 
-module.exports = new EquipmentTemplate("Mercurial Firecracker", "*Strike 3 random foes for @{damage} damage matching the user's element*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Double Firecracker", "Toxic Firecracker"])
+module.exports = new EquipmentTemplate("Mercurial Firecracker", "Strike 3 random foes for @{damage} damage matching the user's element", "Damage x@{critBonus}", "Fire", effect, ["Double Firecracker", "Toxic Firecracker"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: `random${SAFE_DELIMITER}3`, team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/firecracker-toxic.js
+++ b/Source/equipment/firecracker-toxic.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier } = require('../combatantDAO.js');
 const { SAFE_DELIMITER } = require("../../constants.js");
 
-module.exports = new EquipmentTemplate("Toxic Firecracker", "*Strike 3 random foes applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Fire", effect, ["Double Firecracker", "Mercurial Firecracker"])
+module.exports = new EquipmentTemplate("Toxic Firecracker", "Strike 3 random foes applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage", "Damage x@{critBonus}", "Fire", effect, ["Double Firecracker", "Mercurial Firecracker"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: `random${SAFE_DELIMITER}3`, team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 3 }])

--- a/Source/equipment/iceward-base.js
+++ b/Source/equipment/iceward-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Ice Ward", "*Grant @{block} block to an ally and yourself*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Heavy Ice Ward", "Sweeping Ice Ward"])
+module.exports = new EquipmentTemplate("Ice Ward", "Grant @{block} block to an ally and yourself", "Block x@{critBonus}", "Water", effect, ["Heavy Ice Ward", "Sweeping Ice Ward"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/iceward-heavy.js
+++ b/Source/equipment/iceward-heavy.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Heavy Ice Ward", "*Grant @{block} block to an ally and yourself*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Sweeping Ice Ward"])
+module.exports = new EquipmentTemplate("Heavy Ice Ward", "Grant @{block} block to an ally and yourself", "Block x@{critBonus}", "Water", effect, ["Sweeping Ice Ward"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/iceward-sweeping.js
+++ b/Source/equipment/iceward-sweeping.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addBlock, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sweeping Ice Ward", "*Grant @{block} block to all allies (including yourself)*\nCritical Hit💥: Block x@{critBonus}", "Water", effect, ["Heavy Ice Ward"])
+module.exports = new EquipmentTemplate("Sweeping Ice Ward", "Grant @{block} block to all allies (including yourself)", "Block x@{critBonus}", "Water", effect, ["Heavy Ice Ward"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "all", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/infiniteregeneration-base.js
+++ b/Source/equipment/infiniteregeneration-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { removeModifier, addModifier, dealDamage } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Infinite Regeneration", "*Pay @{hpCost} hp to grant an ally @{mod1Stacks} @{mod1}*\nCritical Hit💥: HP Cost / @{critBonus}", "Earth", effect, [])
+module.exports = new EquipmentTemplate("Infinite Regeneration", "Pay @{hpCost} hp to grant an ally @{mod1Stacks} @{mod1}", "HP Cost / @{critBonus}", "Earth", effect, [])
 	.setCategory("Pact")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Regen", stacks: 3 }])

--- a/Source/equipment/inspiration-base.js
+++ b/Source/equipment/inspiration-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Inspiration", "Apply @{mod1Stacks} @{mod1} to an ally*\nCritical Hit💥: Apply @{mod2Stacks} @{mod2} to an delver", "Wind", effect, ["Soothing Inspiration", "Sweeping Inspiration"])
+module.exports = new EquipmentTemplate("Inspiration", "Apply @{mod1Stacks} @{mod1} to an ally", "@{mod2} x@{critBonus}", "Wind", effect, ["Soothing Inspiration", "Sweeping Inspiration"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Power Up", stacks: 50 }])

--- a/Source/equipment/inspiration-reinforcing.js
+++ b/Source/equipment/inspiration-reinforcing.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier, addBlock } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Reinforcing Inspiration", "Apply @{mod1Stacks} @{mod1} and @{block} block to an ally*\nCritical Hit💥: Apply @{mod2Stacks} @{mod2} to an delver", "Wind", effect, ["Soothing Inspiration", "Sweeping Inspiration"])
+module.exports = new EquipmentTemplate("Reinforcing Inspiration", "Apply @{mod1Stacks} @{mod1} and @{block} block to an ally", "@{mod2} x@{critBonus}", "Wind", effect, ["Soothing Inspiration", "Sweeping Inspiration"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Power Up", stacks: 50 }])

--- a/Source/equipment/inspiration-soothing.js
+++ b/Source/equipment/inspiration-soothing.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Soothing Inspiration", "Apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to an ally*\nCritical Hit💥: Apply @{mod2Stacks} @{mod2} to an delver", "Wind", effect, ["Reinforcing Inspiration", "Sweeping Inspiration"])
+module.exports = new EquipmentTemplate("Soothing Inspiration", "Apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to an ally", "@{mod2} x@{critBonus}", "Wind", effect, ["Reinforcing Inspiration", "Sweeping Inspiration"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Regen", stacks: 2 }, { name: "Power Up", stacks: 50 }])

--- a/Source/equipment/inspiration-sweeping.js
+++ b/Source/equipment/inspiration-sweeping.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sweeping Inspiration", "Apply @{mod1Stacks} @{mod1} to all allies*\nCritical Hit💥: Apply @{mod2Stacks} @{mod2} to all allies", "Wind", effect, ["Reinforcing Inspiration", "Soothing Inspiration"])
+module.exports = new EquipmentTemplate("Sweeping Inspiration", "Apply @{mod1Stacks} @{mod1} to all allies", "@{mod2} x@{critBonus}", "Wind", effect, ["Reinforcing Inspiration", "Soothing Inspiration"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "all", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Power Up", stacks: 50 }])

--- a/Source/equipment/lifedrain-base.js
+++ b/Source/equipment/lifedrain-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, gainHealth, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Life Drain", "*Strike a foe for @{damage} @{element} damage, then gain @{healing} hp*\nCritical Hit💥: Healing x@{critBonus}", "Water", effect, ["Flanking Life Drain", "Reactive Life Drain", "Urgent Life Drain"])
+module.exports = new EquipmentTemplate("Life Drain", "Strike a foe for @{damage} @{element} damage, then gain @{healing} hp", "Healing x@{critBonus}", "Water", effect, ["Flanking Life Drain", "Reactive Life Drain", "Urgent Life Drain"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/lifedrain-flanking.js
+++ b/Source/equipment/lifedrain-flanking.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, gainHealth, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Flanking Life Drain", "*Strike a foe for @{damage} @{element} damage and inflict @{mod1Stacks} @{mod1}, then gain @{healing} hp*\nCritical Hit💥: Healing x@{critBonus}", "Water", effect, ["Reactive Life Drain", "Urgent Life Drain"])
+module.exports = new EquipmentTemplate("Flanking Life Drain", "Strike a foe for @{damage} @{element} damage and inflict @{mod1Stacks} @{mod1}, then gain @{healing} hp", "Healing x@{critBonus}", "Water", effect, ["Reactive Life Drain", "Urgent Life Drain"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 2 }])

--- a/Source/equipment/lifedrain-reactive.js
+++ b/Source/equipment/lifedrain-reactive.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, gainHealth, calculateTotalSpeed, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Reactive Life Drain", "*Strike a foe for @{damage} (+@{bonusDamage} if foe went first) @{element} damage, then gain @{healing} hp*\nCritical Hit💥: Healing x@{critBonus}", "Water", effect, ["Flanking Life Drain", "Urgent Life Drain"])
+module.exports = new EquipmentTemplate("Reactive Life Drain", "Strike a foe for @{damage} (+@{bonusDamage} if foe went first) @{element} damage, then gain @{healing} hp", "Healing x@{critBonus}", "Water", effect, ["Flanking Life Drain", "Urgent Life Drain"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/lifedrain-urgent.js
+++ b/Source/equipment/lifedrain-urgent.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, gainHealth, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Urgent Life Drain", "*Strike a foe for @{damage} @{element} damage, then gain @{healing} hp with priority*\nCritical Hit💥: Healing x@{critBonus}", "Water", effect, ["Flanking Life Drain", "Reactive Life Drain"])
+module.exports = new EquipmentTemplate("Urgent Life Drain", "Strike a foe for @{damage} @{element} damage, then gain @{healing} hp with priority", "Healing x@{critBonus}", "Water", effect, ["Flanking Life Drain", "Reactive Life Drain"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/midasstaff-accelerating.js
+++ b/Source/equipment/midasstaff-accelerating.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Accelerating Midas Staff", "*Apply @{mod1Stacks} @{mod1} to a combatant, then gain $${mod2Stacks} @{mod2}*\nCritical Hit💥: @{mod1} x@{critBonus}", "Water", effect, ["Soothing Midas Staff"])
+module.exports = new EquipmentTemplate("Accelerating Midas Staff", "Apply @{mod1Stacks} @{mod1} to a combatant, then gain $${mod2Stacks} @{mod2}", "@{mod1} x@{critBonus}", "Water", effect, ["Soothing Midas Staff"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "any" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 }, { name: "Quicken", stacks: 1 }, { name: "Curse of Midas", stacks: 2 }])

--- a/Source/equipment/midasstaff-base.js
+++ b/Source/equipment/midasstaff-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Midas Staff", "*Apply @{mod1Stacks} @{mod1} to a combatant*\nCritical Hit💥: @{mod1} x@{critBonus}", "Water", effect, ["Accelerating Midas Staff", "Soothing Midas Staff"])
+module.exports = new EquipmentTemplate("Midas Staff", "Apply @{mod1Stacks} @{mod1} to a combatant", "@{mod1} x@{critBonus}", "Water", effect, ["Accelerating Midas Staff", "Soothing Midas Staff"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "any" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 }, { name: "Curse of Midas", stacks: 2 }])

--- a/Source/equipment/midasstaff-soothing.js
+++ b/Source/equipment/midasstaff-soothing.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Soothing Midas Staff", "*Apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to a combatant*\nCritical Hit💥: @{mod1} x@{critBonus}", "Water", effect, ["Accelerating Midas Staff"])
+module.exports = new EquipmentTemplate("Soothing Midas Staff", "Apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to a combatant", "@{mod1} x@{critBonus}", "Water", effect, ["Accelerating Midas Staff"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "any" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 }, { name: "Regen", stacks: 2 }, { name: "Curse of Midas", stacks: 2 }])

--- a/Source/equipment/potionkit-base.js
+++ b/Source/equipment/potionkit-base.js
@@ -3,7 +3,7 @@ const Resource = require('../../Classes/Resource.js');
 const { removeModifier, getFullName } = require('../combatantDAO.js');
 const { rollConsumable } = require('../labyrinths/_labyrinthDictionary');
 
-module.exports = new EquipmentTemplate("Potion Kit", "*Add 1 random potion to loot*\nCritical Hit💥: add @{critBonus} potions instead", "Water", effect, ["Guarding Potion Kit", "Urgent Potion Kit"])
+module.exports = new EquipmentTemplate("Potion Kit", "Add 1 random potion to loot", "Instead add @{critBonus} potions", "Water", effect, ["Guarding Potion Kit", "Urgent Potion Kit"])
 .setCategory("Trinket")
 .setTargetingTags({ target: "none", team: "none" })
 .setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/potionkit-guarding.js
+++ b/Source/equipment/potionkit-guarding.js
@@ -3,7 +3,7 @@ const Resource = require('../../Classes/Resource.js');
 const { removeModifier, getFullName, addBlock } = require('../combatantDAO.js');
 const { rollConsumable } = require('../labyrinths/_labyrinthDictionary');
 
-module.exports = new EquipmentTemplate("Guarding Potion Kit", "*Gain @{block} block and add 1 random potion to loot*\nCritical Hit💥: add @{critBonus} potions instead", "Water", effect, ["Urgent Potion Kit"])
+module.exports = new EquipmentTemplate("Guarding Potion Kit", "Gain @{block} block and add 1 random potion to loot", "Instead add @{critBonus} potions", "Water", effect, ["Urgent Potion Kit"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "none", team: "none" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/potionkit-urgent.js
+++ b/Source/equipment/potionkit-urgent.js
@@ -3,7 +3,7 @@ const Resource = require('../../Classes/Resource.js');
 const { removeModifier, getFullName } = require('../combatantDAO.js');
 const { rollConsumable } = require('../labyrinths/_labyrinthDictionary');
 
-module.exports = new EquipmentTemplate("Urgent Potion Kit", "*Add 1 random potion to loot with priority*\nCritical Hit💥: add @{critBonus} potions instead", "Water", effect, ["Guarding Potion Kit"])
+module.exports = new EquipmentTemplate("Urgent Potion Kit", "Add 1 random potion to loot with priority", "Instead add @{critBonus} potions", "Water", effect, ["Guarding Potion Kit"])
 .setCategory("Trinket")
 .setTargetingTags({ target: "none", team: "none" })
 .setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/scythe-base.js
+++ b/Source/equipment/scythe-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Scythe", "*Strike a foe for @{damage} @{element} damage; instant death if foe is at or below @{bonusDamage} hp*\nCritical Hit💥: Instant death threshold x@{critBonus}", "Wind", effect, ["Lethal Scythe", "Piercing Scythe", "Toxic Scythe"])
+module.exports = new EquipmentTemplate("Scythe", "Strike a foe for @{damage} @{element} damage; instant death if foe is at or below @{bonusDamage} hp", "Instant death threshold x@{critBonus}", "Wind", effect, ["Lethal Scythe", "Piercing Scythe", "Toxic Scythe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/scythe-lethal.js
+++ b/Source/equipment/scythe-lethal.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Lethal Scythe", "*Strike a foe for @{damage} @{element} damage; instant death if foe is at or below @{bonusDamage} hp*\nCritical Hit💥: Instant death threshold x@{critBonus}", "Wind", effect, ["Piercing Scythe", "Toxic Scythe"])
+module.exports = new EquipmentTemplate("Lethal Scythe", "Strike a foe for @{damage} @{element} damage; instant death if foe is at or below @{bonusDamage} hp", "Instant death threshold x@{critBonus}", "Wind", effect, ["Piercing Scythe", "Toxic Scythe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/scythe-piercing.js
+++ b/Source/equipment/scythe-piercing.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Piercing Scythe", "*Strike a foe for @{damage} @{element} unblockable damage; instant death if foe is at or below @{bonusDamage} hp*\nCritical Hit💥: Instant death threshold x@{critBonus}", "Wind", effect, ["Lethal Scythe", "Toxic Scythe"])
+module.exports = new EquipmentTemplate("Piercing Scythe", "Strike a foe for @{damage} @{element} unblockable damage; instant death if foe is at or below @{bonusDamage} hp", "Instant death threshold x@{critBonus}", "Wind", effect, ["Lethal Scythe", "Toxic Scythe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/scythe-toxic.js
+++ b/Source/equipment/scythe-toxic.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Toxic Scythe", "*Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage; instant death if foe is at or below @{bonusDamage} hp*\nCritical Hit💥: Instant death threshold x@{critBonus}", "Wind", effect, ["Lethal Scythe", "Piercing Scythe"])
+module.exports = new EquipmentTemplate("Toxic Scythe", "Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage; instant death if foe is at or below @{bonusDamage} hp", "Instant death threshold x@{critBonus}", "Wind", effect, ["Lethal Scythe", "Piercing Scythe"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 3 }])

--- a/Source/equipment/sickle-base.js
+++ b/Source/equipment/sickle-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sickle", "*Strike a foe for @{damage} (+5% foe max hp) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Water", effect, ["Hunter's Sickle", "Sharpened Sickle", "Toxic Sickle"])
+module.exports = new EquipmentTemplate("Sickle", "Strike a foe for @{damage} (+5% foe max hp) @{element} damage", "Damage x@{critBonus}", "Water", effect, ["Hunter's Sickle", "Sharpened Sickle", "Toxic Sickle"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/sickle-hunters.js
+++ b/Source/equipment/sickle-hunters.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Hunter's Sickle", "*Strike a foe for @{damage} (+5% foe max hp) @{element} damage, gain @{bonusDamage}g on kill*\nCritical Hit💥: Damage x@{critBonus}", "Water", effect, ["Sharpened Sickle", "Toxic Sickle"])
+module.exports = new EquipmentTemplate("Hunter's Sickle", "Strike a foe for @{damage} (+5% foe max hp) @{element} damage, gain @{bonusDamage}g on kill", "Damage x@{critBonus}", "Water", effect, ["Sharpened Sickle", "Toxic Sickle"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/sickle-sharpened.js
+++ b/Source/equipment/sickle-sharpened.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sharpened Sickle", "*Strike a foe for @{damage} (+5% foe max hp) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Water", effect, ["Hunter's Sickle", "Toxic Sickle"])
+module.exports = new EquipmentTemplate("Sharpened Sickle", "Strike a foe for @{damage} (+5% foe max hp) @{element} damage", "Damage x@{critBonus}", "Water", effect, ["Hunter's Sickle", "Toxic Sickle"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/sickle-toxic.js
+++ b/Source/equipment/sickle-toxic.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, dealDamage, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Toxic Sickle", "*Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} (+5% foe max hp) @{element} damage and apply *\nCritical Hit💥: Damage x@{critBonus}", "Water", effect, ["Hunter's Sickle", "Sharpened Sickle"])
+module.exports = new EquipmentTemplate("Toxic Sickle", "Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} (+5% foe max hp) @{element} damage and apply", "Damage x@{critBonus}", "Water", effect, ["Hunter's Sickle", "Sharpened Sickle"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 3 }])

--- a/Source/equipment/spear-base.js
+++ b/Source/equipment/spear-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Spear", "*Strike a foe for @{damage} @{element} damage*\nCritical Hit💥: Inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Lethal Spear", "Reactive Spear", "Sweeping Spear"])
+module.exports = new EquipmentTemplate("Spear", "Strike a foe for @{damage} @{element} damage", "Also inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Lethal Spear", "Reactive Spear", "Sweeping Spear"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }])

--- a/Source/equipment/spear-lethal.js
+++ b/Source/equipment/spear-lethal.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Lethal Spear", "*Strike a foe for @{damage} @{element} damage*\nCritical Hit💥: Inflict @{mod1Stacks} @{mod1} and damage x@{critBonus}", "Fire", effect, ["Reactive Spear", "Sweeping Spear"])
+module.exports = new EquipmentTemplate("Lethal Spear", "Strike a foe for @{damage} @{element} damage", "Damage x@{critBonus}, also inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Reactive Spear", "Sweeping Spear"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }])

--- a/Source/equipment/spear-reactive.js
+++ b/Source/equipment/spear-reactive.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, calculateTotalSpeed, getFullName } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Reactive Spear", "*Strike a foe for @{damage} (+@{bonusDamage} if foe went first) @{element} damage*\nCritical Hit💥: Inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Lethal Spear", "Sweeping Spear"])
+module.exports = new EquipmentTemplate("Reactive Spear", "Strike a foe for @{damage} (+@{bonusDamage} if foe went first) @{element} damage", "Also inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Lethal Spear", "Sweeping Spear"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }])

--- a/Source/equipment/spear-sweeping.js
+++ b/Source/equipment/spear-sweeping.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier } = require("../combatantDAO.js");
 
-module.exports = new EquipmentTemplate("Sweeping Spear", "*Strike all foes for @{damage} @{element} damage*\nCritical Hit💥: Inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Lethal Spear", "Reactive Spear"])
+module.exports = new EquipmentTemplate("Sweeping Spear", "Strike all foes for @{damage} @{element} damage", "Also inflict @{mod1Stacks} @{mod1}", "Fire", effect, ["Lethal Spear", "Reactive Spear"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "all", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }])

--- a/Source/equipment/sunflare-accelerating.js
+++ b/Source/equipment/sunflare-accelerating.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Accelerating Sun Flare", "*Inflict @{mod1Stacks} @{mod1} on a foe, then gain @{mod2Stacks} @{mod2} with priority*\nCritical Hit💥: Inflict @{mod3Stacks} @{mod3} as well", "Fire", effect, ["Evasive Sun Flare", "Tormenting Sun Flare"])
+module.exports = new EquipmentTemplate("Accelerating Sun Flare", "Inflict @{mod1Stacks} @{mod1} on a foe, then gain @{mod2Stacks} @{mod2} with priority", "Also inflict @{mod3Stacks} @{mod3}", "Fire", effect, ["Evasive Sun Flare", "Tormenting Sun Flare"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Quicken", stacks: 1 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/sunflare-base.js
+++ b/Source/equipment/sunflare-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sun Flare", "*Inflict @{mod1Stacks} @{mod1} on a foe with priority*\nCritical Hit💥: Inflict @{mod2Stacks} @{mod2} as well", "Fire", effect, ["Accelerating Sun Flare", "Evasive Sun Flare", "Tormenting Sun Flare"])
+module.exports = new EquipmentTemplate("Sun Flare", "Inflict @{mod1Stacks} @{mod1} on a foe with priority", "Also inflict @{mod2Stacks} @{mod2}", "Fire", effect, ["Accelerating Sun Flare", "Evasive Sun Flare", "Tormenting Sun Flare"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/sunflare-evasive.js
+++ b/Source/equipment/sunflare-evasive.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Evasive Sun Flare", "*Inflict @{mod1Stacks} @{mod1} on a foe and gain @{mod2Stacks} @{mod2} with priority*\nCritical Hit💥: Inflict @{mod3Stacks} @{mod3} as well", "Fire", effect, ["Accelerating Sun Flare", "Tormenting Sun Flare"])
+module.exports = new EquipmentTemplate("Evasive Sun Flare", "Inflict @{mod1Stacks} @{mod1} on a foe and gain @{mod2Stacks} @{mod2} with priority", "Also inflict @{mod3Stacks} @{mod3}", "Fire", effect, ["Accelerating Sun Flare", "Tormenting Sun Flare"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/sunflare-tormenting.js
+++ b/Source/equipment/sunflare-tormenting.js
@@ -2,7 +2,7 @@ const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 const { isDebuff } = require('../Modifiers/_modifierDictionary.js');
 
-module.exports = new EquipmentTemplate("Tormenting Sun Flare", "*Inflict @{mod1Stacks} @{mod1} and 1 of each of a foe's debuffs on that foe with priority*\nCritical Hit💥: Inflict @{mod2Stacks} @{mod2} as well", "Fire", effect, ["Accelerating Sun Flare", "Evasive Sun Flare"])
+module.exports = new EquipmentTemplate("Tormenting Sun Flare", "Inflict @{mod1Stacks} @{mod1} and 1 of each of a foe's debuffs on that foe with priority", "Also inflict @{mod2Stacks} @{mod2}", "Fire", effect, ["Accelerating Sun Flare", "Evasive Sun Flare"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 }])

--- a/Source/equipment/sword-accelerating.js
+++ b/Source/equipment/sword-accelerating.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Accelerating Sword", "*Strike a foe for @{damage} @{element} damage, then gain @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}*\nCritical Hit💥: Damage x@{critBonus}", "Earth", effect, ["Guarding Sword", "Reckless Sword"])
+module.exports = new EquipmentTemplate("Accelerating Sword", "Strike a foe for @{damage} @{element} damage, then gain @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}", "Damage x@{critBonus}", "Earth", effect, ["Guarding Sword", "Reckless Sword"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Quicken", stacks: 1 }])

--- a/Source/equipment/sword-base.js
+++ b/Source/equipment/sword-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Sword", "*Strike a foe for @{damage} @{element} damage and gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Damage x@{critBonus}", "Earth", effect, ["Accelerating Sword", "Guarding Sword", "Reckless Sword"])
+module.exports = new EquipmentTemplate("Sword", "Strike a foe for @{damage} @{element} damage and gain @{mod1Stacks} @{mod1}", "Damage x@{critBonus}", "Earth", effect, ["Accelerating Sword", "Guarding Sword", "Reckless Sword"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }])

--- a/Source/equipment/sword-guarding.js
+++ b/Source/equipment/sword-guarding.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, addBlock, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Guarding Sword", "*Strike a foe for @{damage} @{element} damage, then gain @{block} block and @{mod1Stacks} @{mod1}*\nCritical Hit💥: Damage x@{critBonus}", "Earth", effect, ["Accelerating Sword", "Reckless Sword"])
+module.exports = new EquipmentTemplate("Guarding Sword", "Strike a foe for @{damage} @{element} damage, then gain @{block} block and @{mod1Stacks} @{mod1}", "Damage x@{critBonus}", "Earth", effect, ["Accelerating Sword", "Reckless Sword"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }])

--- a/Source/equipment/sword-reckless.js
+++ b/Source/equipment/sword-reckless.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Reckless Sword", "*Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage and gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Damage x@{critBonus}", "Earth", effect, ["Accelerating Sword", "Guarding Sword"])
+module.exports = new EquipmentTemplate("Reckless Sword", "Strike a foe for @{damage} (+@{bonusDamage} if you have 0 block) @{element} damage and gain @{mod1Stacks} @{mod1}", "Damage x@{critBonus}", "Earth", effect, ["Accelerating Sword", "Guarding Sword"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }])

--- a/Source/equipment/vigilancecharm-base.js
+++ b/Source/equipment/vigilancecharm-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Vigilance Charm", "*Gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Gain @{mod2Stacks} @{mod2}", "Earth", effect, ["Long Vigilance Charm", "Devoted Vigilance Charm", "Guarding Vigilance Charm"])
+module.exports = new EquipmentTemplate("Vigilance Charm", "Gain @{mod1Stacks} @{mod1}", "Instead gain @{mod2Stacks} @{mod2}", "Earth", effect, ["Long Vigilance Charm", "Devoted Vigilance Charm", "Guarding Vigilance Charm"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 3 }, { name: "Vigilance", stacks: 5 }])

--- a/Source/equipment/vigilancecharm-devoted.js
+++ b/Source/equipment/vigilancecharm-devoted.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Devoted Vigilance Charm", "*Grant an ally @{mod1Stacks} @{mod1}*\nCritical Hit💥: Grant ally @{mod2Stacks} @{mod2}", "Earth", effect, ["Long Vigilance Charm", "Guarding Vigilance Charm"])
+module.exports = new EquipmentTemplate("Devoted Vigilance Charm", "Grant an ally @{mod1Stacks} @{mod1}", "Insted grant @{mod2Stacks} @{mod2}", "Earth", effect, ["Long Vigilance Charm", "Guarding Vigilance Charm"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "single", team: "delver" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 3 }, { name: "Vigilance", stacks: 5 }])

--- a/Source/equipment/vigilancecharm-guarding.js
+++ b/Source/equipment/vigilancecharm-guarding.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier, addBlock } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Guarding Vigilance Charm", "*Gain @{mod1Stacks} @{mod1} and @{block} block*\nCritical Hit💥: Gain @{mod2Stacks} @{mod2} and Block x@{critBonus}", "Earth", effect, ["Long Vigilance Charm", "Guarding Vigilance Charm"])
+module.exports = new EquipmentTemplate("Guarding Vigilance Charm", "Gain @{mod1Stacks} @{mod1} and @{block} block", "Instead gain @{mod2Stacks} @{mod2} and block x@{critBonus}", "Earth", effect, ["Long Vigilance Charm", "Guarding Vigilance Charm"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 3 }, { name: "Vigilance", stacks: 5 }])

--- a/Source/equipment/vigilancecharm-long.js
+++ b/Source/equipment/vigilancecharm-long.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Long Vigilance Charm", "*Gain @{mod1Stacks} @{mod1}*\nCritical Hit💥: Gain @{mod2Stacks} @{mod2}", "Earth", effect, ["Devoted Vigilance Charm", "Guarding Vigilance Charm"])
+module.exports = new EquipmentTemplate("Long Vigilance Charm", "Gain @{mod1Stacks} @{mod1}", "Instead gain @{mod2Stacks} @{mod2}", "Earth", effect, ["Devoted Vigilance Charm", "Guarding Vigilance Charm"])
 	.setCategory("Trinket")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 4 }, { name: "Vigilance", stacks: 6 }])

--- a/Source/equipment/warcry-base.js
+++ b/Source/equipment/warcry-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("War Cry", "*Inflict @{mod1Stacks} @{mod1} on a foe and all foes with Exposed*\nCritical Hit💥: Inflict @{mod2Stacks} @{mod2} instead", "Fire", effect, ["Charging War Cry", "Tormenting War Cry"])
+module.exports = new EquipmentTemplate("War Cry", "Inflict @{mod1Stacks} @{mod1} on a foe and all foes with Exposed", "@{mod2} x@{critBonus}", "Fire", effect, ["Charging War Cry", "Tormenting War Cry"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 2 }])

--- a/Source/equipment/warcry-charging.js
+++ b/Source/equipment/warcry-charging.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Charging War Cry", "*Inflict @{mod1Stacks} @{mod1} on a foe and all foes with Exposed then gain @{mod3Stacks} @{mod3}*\nCritical Hit💥: Inflict @{mod2Stacks} @{mod2} instead", "Fire", effect, ["Tormenting War Cry"])
+module.exports = new EquipmentTemplate("Charging War Cry", "Inflict @{mod1Stacks} @{mod1} on a foe and all foes with Exposed then gain @{mod3Stacks} @{mod3}", "@{mod2} x@{critBonus}", "Fire", effect, ["Tormenting War Cry"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 2 }, { name: "Power Up", stacks: 25 }])

--- a/Source/equipment/warcry-tormenting.js
+++ b/Source/equipment/warcry-tormenting.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Tormenting War Cry", "*Inflict @{mod1Stacks} @{mod1} and 1 of each of a the foe's debuffs on a foe and all foes with Exposed*\nCritical Hit💥: Inflict @{mod2Stacks} @{mod2} instead", "Fire", effect, ["Charging War Cry"])
+module.exports = new EquipmentTemplate("Tormenting War Cry", "Inflict @{mod1Stacks} @{mod1} and 1 of each of a the foe's debuffs on a foe and all foes with Exposed", "@{mod2} x@{critBonus}", "Fire", effect, ["Charging War Cry"])
 	.setCategory("Spell")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 2 }])

--- a/Source/equipment/warhammer-base.js
+++ b/Source/equipment/warhammer-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Warhammer", "*Strike a foe for @{damage} (+@{bonusDamage} if foe is already stunned) @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Earth", effect, ["Piercing Warhammer"])
+module.exports = new EquipmentTemplate("Warhammer", "Strike a foe for @{damage} (+@{bonusDamage} if foe is already stunned) @{element} damage", "Damage x@{critBonus}", "Earth", effect, ["Piercing Warhammer"])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])

--- a/Source/equipment/warhammer-piercing.js
+++ b/Source/equipment/warhammer-piercing.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { dealDamage, addModifier, getFullName } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Piercing Warhammer", "*Strike a foe for @{damage} (+@{bonusDamage} if foe is already stunned) unblockable @{element} damage*\nCritical Hit💥: Damage x@{critBonus}", "Earth", effect, [])
+module.exports = new EquipmentTemplate("Piercing Warhammer", "Strike a foe for @{damage} (+@{bonusDamage} if foe is already stunned) unblockable @{element} damage", "Damage x@{critBonus}", "Earth", effect, [])
 	.setCategory("Weapon")
 	.setTargetingTags({ target: "single", team: "enemy" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }])


### PR DESCRIPTION
Summary
-------
- split crit bonus text out of equipment descriptions
- started convention to have crit bonus text modify base description instead of replace
- fixed expression for poison damage in modifier description

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] checked equipment descriptions directly (checked Sickle, Potion Kit, Accelerating Cloak, and Guarding Vigilance Charm)
- [x] checked parsed poison modifier description directly

Issue
-----
Closes #514 