### PR TITLE
#451: Add equipment durability to merchant listings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@
 - Fixed Potion Kit upgrades cost being the same as the unupgraded Potion Kit
 - *Daggers* can now upgrade to *Slowing Daggers* instead of *Wicked Daggers*
 - Adventures that end by `/give-up` no longer provide score to player profiles
+- Merchants now show how many uses equipment they're selling has
 
 #### Prophets of the Labyrinth Version 0.10.0:
 - Added **Consumables**: these resources can be used by any party member during combat at priority speed

--- a/Source/roomDAO.js
+++ b/Source/roomDAO.js
@@ -294,8 +294,9 @@ function generateMerchantRows(adventure) {
 			categorizedResources[groupName].forEach((resource, i) => {
 				if (adventure.room.resources[resource].count > 0) {
 					const cost = getEquipmentProperty(resource, "cost");
+					const maxUses = getEquipmentProperty(resource, "maxUses");
 					options.push({
-						label: `${cost}g: ${resource}`,
+						label: `${cost}g: ${resource} (${maxUses} uses)`,
 						description: buildEquipmentDescription(resource, false),
 						value: `${resource}${SAFE_DELIMITER}${i}`
 					})


### PR DESCRIPTION
Summary
-------
- add gear durability to merchant listsings

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] verified in a merchant room

Issue
-----
Closes #451