### PR TITLE
#578: change crit and gear drop rate to allow compounding artifacts

### DIFF
--- a/Classes/Artifact.js
+++ b/Classes/Artifact.js
@@ -2,9 +2,10 @@ const { MAX_MESSAGE_ACTION_ROWS, MAX_BUTTONS_PER_ROW } = require("../constants.j
 const { calculateTagContent } = require("../helpers");
 
 module.exports = class Artifact {
-	constructor(nameInput, descriptionInput) {
+	constructor(nameInput, descriptionInput, scalingDescriptionInput) {
 		this.name = nameInput;
 		this.description = descriptionInput;
+		this.scalingDescription = scalingDescriptionInput;
 	}
 	element = "";
 	/** @type {import("discord.js").EmbedField} */

--- a/Classes/Combatant.js
+++ b/Classes/Combatant.js
@@ -11,8 +11,7 @@ module.exports = class Combatant {
 	roundSpeed = 0;
 	actionSpeed = 0;
 	crit = false;
-	critNumerator = 1;
-	critDenominator = 4;
+	critBonus = 0;
 	element = "not picked";
 	/** @type {{[modifierName: string]: number}} */
 	modifiers = {};
@@ -59,18 +58,12 @@ module.exports = class Combatant {
 		return this;
 	}
 
-	/** Gets the numerator of the combatant's critical hit chance. Starts at 1. Delver has an overwrite that uses `hawkTailfeatherCount`.
-	 * @param {number} hawkTailfeatherCount
+	/** Adds the given percent to the combatant's individual increased chance to crit
+	 * @param {number} percent
 	 */
-	getCritNumerator(hawkTailfeatherCount) {
-		return this.critNumerator;
-	}
-
-	/** Gets the denominator of the combatant's critical hit chance. Starts at 4. Delver has an overwrite that uses `hawkTailfeatherCount`.
-	 * @param {number} hawkTailfeatherCount
-	 */
-	getCritDenominator(hawkTailfeatherCount) {
-		return this.critDenominator;
+	setCritBonus(percent) {
+		this.critBonus += percent;
+		return this;
 	}
 
 	/** Get the number of stacks of the given modifier the combatant has

--- a/Classes/Delver.js
+++ b/Classes/Delver.js
@@ -30,18 +30,4 @@ module.exports = class Delver extends Combatant {
 		this.predict = predictEnum;
 		return this;
 	}
-
-	/** Overwrite of Combatant.getCritNumerator(). `hawkTailfeatherCount` included so delvers can modify value via artifacts.
-	 * @param {number} hawkTailfeatherCount
-	 */
-	getCritNumerator(hawkTailfeatherCount) {
-		return this.critNumerator + (hawkTailfeatherCount / 2);
-	}
-
-	/** Overwrite of Combatant.getCritDenominator(). `hawkTailfeatherCount` included so delvers can modify value via artifacts.
-	 * @param {number} hawkTailfeatherCount
-	 */
-	getCritDenominator(hawkTailfeatherCount) {
-		return this.critDenominator + (hawkTailfeatherCount / 2);
-	}
 }

--- a/Classes/Enemy.js
+++ b/Classes/Enemy.js
@@ -50,25 +50,10 @@ module.exports = class Enemy extends Combatant {
 		return this;
 	}
 
-	/** Set the numerator of the enemy's critical hit rate.
-	 * @param {number} numeratorInput
-	 */
-	setCritNumerator(numeratorInput) {
-		this.critNumerator = numeratorInput;
-		return this;
-	}
-
-	/** Set the denominator of the enemy's critical hit rate.
-	 * @param {number} denominatorInput
-	 */
-	setCritDenominator(denominatorInput) {
-		this.critDenominator = denominatorInput;
-		return this;
-	}
-
 	/** Marks the enemy as an artifact guardian or final boss, which shouldn't randomize hp */
 	markAsBoss() {
 		this.shouldRandomizeHP = false;
+		this.setCritBonus(15);
 		return this;
 	}
 

--- a/Source/Artifacts/amethystspyglass.js
+++ b/Source/Artifacts/amethystspyglass.js
@@ -1,5 +1,5 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Amethyst Spyglass", "Get a discount on scouting of @{copies*5} gold.")
+module.exports = new Artifact("Amethyst Spyglass", "Get a discount on scouting of @{copies*5} gold.", "Increase discount by 5g per spyglass")
 	.setElement("Untyped")
 	.setFlavorText({ name: "*Additional Notes*", value: "*Peering through it makes things look blocky*" })

--- a/Source/Artifacts/bloodshieldsword.js
+++ b/Source/Artifacts/bloodshieldsword.js
@@ -1,5 +1,5 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Bloodshield Sword", "When being healed, convert each point of excess hp to @{copies} block.")
+module.exports = new Artifact("Bloodshield Sword", "When being healed, convert each point of excess hp to @{copies} block.", "Increase block conversion by 1 for each sword")
 	.setElement("Untyped")
 	.setFlavorText({ name: "*Additional Notes*", value: "*What's next, a sword that heals those it slashes?*" })

--- a/Source/Artifacts/crystalshard.js
+++ b/Source/Artifacts/crystalshard.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Crystal Shard", "Spells have a @{0.85^copies*-1+1*100}% chance to avoid using durability when used.")
+module.exports = new Artifact("Crystal Shard", "Spells have a @{0.85^copies*-1+1*100}% chance to avoid using durability when used.", "Increase chance of saving durability (multiplicatively) by 15% per shard")
 	.setElement("Untyped")

--- a/Source/Artifacts/enchantedmap.js
+++ b/Source/Artifacts/enchantedmap.js
@@ -1,5 +1,5 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Enchanted Map", "When picking rooms, roll @{copies} more option (duplicate rolls possible, @{buttons} unique options max).")
+module.exports = new Artifact("Enchanted Map", "When picking rooms, roll @{copies} more option (duplicate rolls possible, @{buttons} unique options max).", "Increase number of rolls by 1 per map")
 	.setElement("Untyped")
 	.setFlavorText({ name: "*Additional Notes*", value: "*Makes routing real ez*" })

--- a/Source/Artifacts/hammerspaceholster.js
+++ b/Source/Artifacts/hammerspaceholster.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Hammerspace Holster", "Delvers can carry @{copies} more piece(s) of equipment (@{rows} max).")
+module.exports = new Artifact("Hammerspace Holster", "Delvers can carry @{copies} more piece(s) of equipment (@{rows} max).", "Increase capacity by 1 per holster")
 	.setElement("Untyped")

--- a/Source/Artifacts/hawktailfeather.js
+++ b/Source/Artifacts/hawktailfeather.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Hawk Tailfeather", "Increases the chance moves will critically hit.")
+module.exports = new Artifact("Hawk Tailfeather", "Increases the chance moves will critically hit by @{0.85^copies*-1+1*100}%.", "Increase chance of crit (multiplicatively) by 15% per feather")
 	.setElement("Untyped")

--- a/Source/Artifacts/negativeoneleafclover.js
+++ b/Source/Artifacts/negativeoneleafclover.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Negative-One Leaf Clover", "Increases chance of finding upgraded equipment.")
+module.exports = new Artifact("Negative-One Leaf Clover", "Increases chance of finding upgraded equipment by @{0.80^copies*-1+1*100}%.", "Increase upgrade chance (multiplicatively) by 20% per clover")
 	.setElement("Untyped")

--- a/Source/Artifacts/oilpainting.js
+++ b/Source/Artifacts/oilpainting.js
@@ -1,5 +1,5 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Oil Painting", "Gain 500 gold when obtaining this artifact.")
+module.exports = new Artifact("Oil Painting", "Gain 500g when obtaining this artifact.", "Gain 500g each time")
 	.setElement("Untyped")
 	.setFlavorText({ name: "Additional Notes", value: "This will likely end up in the museum of a powerful nation." });

--- a/Source/Artifacts/phoenixfruitblossom.js
+++ b/Source/Artifacts/phoenixfruitblossom.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Phoenix Fruit Blossom", "Gain 1 life when obtaining this artifact.")
+module.exports = new Artifact("Phoenix Fruit Blossom", "Gain 1 life when obtaining this artifact.", "Gain 1 live each time")
 	.setElement("Untyped")

--- a/Source/Artifacts/phoenixfruitblossom.js
+++ b/Source/Artifacts/phoenixfruitblossom.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Phoenix Fruit Blossom", "Gain 1 life when obtaining this artifact.", "Gain 1 live each time")
+module.exports = new Artifact("Phoenix Fruit Blossom", "Gain 1 life when obtaining this artifact.", "Gain 1 life each time")
 	.setElement("Untyped")

--- a/Source/Artifacts/piggybank.js
+++ b/Source/Artifacts/piggybank.js
@@ -1,4 +1,4 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Piggy Bank", "Gain @{copies*5}% of your current gold when you enter a new room.")
+module.exports = new Artifact("Piggy Bank", "Gain @{copies*5}% of your current gold when you enter a new room.", "Increase rate of interest (additively) by 5% per piggy bank")
 	.setElement("Untyped")

--- a/Source/Artifacts/spiralfunnel.js
+++ b/Source/Artifacts/spiralfunnel.js
@@ -1,5 +1,5 @@
 const Artifact = require("../../Classes/Artifact.js");
 
-module.exports = new Artifact("Spiral Funnel", "Increase Poison damage dealt to enemies by @{copies*5} per stack.")
+module.exports = new Artifact("Spiral Funnel", "Increase Poison damage dealt to enemies by @{copies*5} per stack.", "Increase damage per stack by 5 per funnel")
 	.setElement("Untyped")
 	.setFlavorText({ name: "Artifact Usage Survey Report", value: "Found to be a major contributor to toxic spiralling in dungeon delves" })

--- a/Source/Enemies/bloodtailhawk.js
+++ b/Source/Enemies/bloodtailhawk.js
@@ -9,7 +9,7 @@ module.exports = new Enemy("Bloodtail Hawk")
 	.setSpeed(105)
 	.setElement("Wind")
 	.setStaggerThreshold(1)
-	.setCritDenominator(3);
+	.setCritBonus(30);
 
 function rakeEffect([target], user, isCrit, adventure) {
 	let damage = 50;

--- a/Source/Selects/artifact.js
+++ b/Source/Selects/artifact.js
@@ -3,6 +3,7 @@ const { SAFE_DELIMITER } = require('../../constants.js');
 const Select = require('../../Classes/Select.js');
 const { getArtifact } = require('../Artifacts/_artifactDictionary.js');
 const { getAdventure } = require('../adventureDAO.js');
+const { getEmoji } = require('../elementHelpers.js');
 
 const id = "artifact";
 module.exports = new Select(id, (interaction, args) => {
@@ -10,9 +11,9 @@ module.exports = new Select(id, (interaction, args) => {
 	const [artifactName, artifactCount] = interaction.values[0].split(SAFE_DELIMITER);
 	let artifact = getArtifact(artifactName);
 	let embed = new EmbedBuilder()
-		.setTitle(`${artifactName} x ${artifactCount}`)
+		.setTitle(`${getEmoji(artifact.element)} ${artifactName} x ${artifactCount}`)
 		.setDescription(artifact.dynamicDescription(artifactCount))
-		.addFields({ name: "Scaling", value: artifact.scalingDescription }, { name: "Element", value: artifact.element })
+		.addFields({ name: "Scaling", value: artifact.scalingDescription })
 		.setFooter({ text: "Imaginary Horizons Productions", iconURL: "https://cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png" });
 	if (artifact.flavorText) {
 		embed.addFields(artifact.flavorText);

--- a/Source/Selects/artifact.js
+++ b/Source/Selects/artifact.js
@@ -12,7 +12,7 @@ module.exports = new Select(id, (interaction, args) => {
 	let embed = new EmbedBuilder()
 		.setTitle(`${artifactName} x ${artifactCount}`)
 		.setDescription(artifact.dynamicDescription(artifactCount))
-		.addFields({ name: "Element", value: artifact.element })
+		.addFields({ name: "Scaling", value: artifact.scalingDescription }, { name: "Element", value: artifact.element })
 		.setFooter({ text: "Imaginary Horizons Productions", iconURL: "https://cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png" });
 	if (artifact.flavorText) {
 		embed.addFields(artifact.flavorText);

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -288,7 +288,7 @@ exports.newRound = function (adventure, thread, lastRoundText) {
 			combatant.roundSpeed = Math.floor(combatant.speed * percentBonus);
 
 			// Roll Critical Hit
-			const baseCritChance = 1 / 4;
+			const baseCritChance = (1 + (combatant.critBonus / 100)) * (1 / 4);
 			const max = 144;
 			let threshold = max * baseCritChance;
 			if (combatant instanceof Delver) {

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -288,7 +288,7 @@ exports.newRound = function (adventure, thread, lastRoundText) {
 			combatant.roundSpeed = Math.floor(combatant.speed * percentBonus);
 
 			// Roll Critical Hit
-			const baseCritChance = (1 + (combatant.critBonus / 100)) * (1 / 4);
+			const baseCritChance = (1 + (combatant.critBonus / 100)) * (1 / 4) - 1;
 			const max = 144;
 			let threshold = max * baseCritChance;
 			if (combatant instanceof Delver) {

--- a/Source/equipment/cloak-accelerating.js
+++ b/Source/equipment/cloak-accelerating.js
@@ -5,6 +5,7 @@ module.exports = new EquipmentTemplate("Accelerating Cloak", "Gain @{mod1Stacks}
 	.setCategory("Armor")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Quicken", stacks: 1 }])
+	.setBonus(1) // Evade stacks
 	.setCost(350)
 	.setUses(10);
 

--- a/Source/equipment/cloak-base.js
+++ b/Source/equipment/cloak-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const { addModifier, removeModifier } = require('../combatantDAO.js');
 
-module.exports = new EquipmentTemplate("Cloak", "Gain @{mod1Stacks} @{mod1}", "@{mod2} +@{bonus}", "Wind", effect, ["Accelerating Cloak", "Long Cloak", "Thick Cloak"])
+module.exports = new EquipmentTemplate("Cloak", "Gain @{mod1Stacks} @{mod1}", "@{mod1} +@{bonus}", "Wind", effect, ["Accelerating Cloak", "Long Cloak", "Thick Cloak"])
 	.setCategory("Armor")
 	.setTargetingTags({ target: "self", team: "self" })
 	.setModifiers([{ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }])

--- a/Source/moveDAO.js
+++ b/Source/moveDAO.js
@@ -50,9 +50,8 @@ exports.resolveMove = async function (move, adventure) {
 						if (crystalShardCount > 0) {
 							const durabilitySaveChance = 1 - 0.85 ** crystalShardCount;
 							const max = 144;
-							const rn = generateRandomNumber(adventure, max, "battle");
 							adventure.updateArtifactStat("Crystal Shard", "Expected Durability Saved", durabilitySaveChance.toFixed(2));
-							if (rn < max * durabilitySaveChance) {
+							if (generateRandomNumber(adventure, max, "battle") < max * durabilitySaveChance) {
 								decrementDurability = false;
 								adventure.updateArtifactStat("Crystal Shard", "Actual Durability Saved", 1);
 							}


### PR DESCRIPTION
Summary
-------
- added scaling description to artifacts
- changed Hawk Tailfeather to increase crit chance by 15% compounding
- changed Negative-One Leaf Clover to increase upgrade roll chance by 20% compounding

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] rolling for crit doesn't crash
- [x] rolling for loot doesn't crash

Issue
-----
Closes #578 
