### PR TITLE
#505: allow Punch unless too much gear

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@
 - *Reckless* gear variants (and *Battleaxes*) now have high base damage and apply *Exposed* to the user
 - Fixed Potion Kit upgrades cost being the same as the unupgraded Potion Kit
 - *Daggers* can now upgrade to *Slowing Daggers* instead of *Wicked Daggers*
+- *Punch* is now always available unless the delver is full on gear
 - Adventures that end by `/give-up` no longer provide score to player profiles
 - Merchants now show how many uses equipment they're selling has
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@
 - *Reckless* gear variants (and *Battleaxes*) now have high base damage and apply *Exposed* to the user
 - Fixed Potion Kit upgrades cost being the same as the unupgraded Potion Kit
 - *Daggers* can now upgrade to *Slowing Daggers* instead of *Wicked Daggers*
-- *Punch* is now always available unless the delver is full on gear
+- *Punch* is now always available unless the delver is full on gear (damage reduced to 35 to be less than the average resisted damage)
 - Adventures that end by `/give-up` no longer provide score to player profiles
 - Merchants now show how many uses equipment they're selling has
 

--- a/Source/Buttons/readymove.js
+++ b/Source/Buttons/readymove.js
@@ -40,8 +40,7 @@ module.exports = new Button(id, (interaction, args) => {
 			});
 			const components = [];
 			const usableMoves = delver.equipment.filter(equip => equip.uses > 0);
-			const needsPunch = !usableMoves.some(move => getEquipmentProperty(move.name, 'category') === "Weapon");
-			if (needsPunch && usableMoves.length < adventure.getEquipmentCapacity()) {
+			if (usableMoves.length < adventure.getEquipmentCapacity()) {
 				usableMoves.unshift({ name: "Punch", uses: Infinity });
 			}
 			for (let i = 0; i < usableMoves.length; i++) {

--- a/Source/equipment/-punch.js
+++ b/Source/equipment/-punch.js
@@ -7,7 +7,7 @@ module.exports = new EquipmentTemplate("Punch", "Strike a foe for @{damage} @{el
 	.setModifiers([])
 	.setCost(0)
 	.setUses(Infinity)
-	.setDamage(50);
+	.setDamage(35);
 
 function effect([target], user, isCrit, adventure) {
 	if (target.hp < 1) {


### PR DESCRIPTION
Summary
-------
- allow Punch except when delver has too much gear
- reduce Punch damage to 35 (to be less than average resisted damage)

Local Tests Performed
---------------------
- [x] saw Punch enabled on Chemist in battle

Issue
-----
Closes #505