### PR TITLE
#597: fix overly-greedy matching in calculateTagContent

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -116,9 +116,9 @@ exports.parseExpression = function (expression, nValue) {
  */
 exports.calculateTagContent = function (text, tags) {
 	for (const { tag, count } of tags) {
-		const taggedGlobal = new RegExp(`@{(.*${tag}.*)}`, "g");
+		const taggedGlobal = new RegExp(`@{(.*?${tag}.*?)}`, "g");
 		const untagged = new RegExp(tag, "g");
-		const taggedSingle = new RegExp(`@{(.*${tag}.*)}`);
+		const taggedSingle = new RegExp(`@{(.*?${tag}.*?)}`);
 
 		for (const match of text.matchAll(taggedGlobal)) {
 			const countExpression = match?.[1].replace(untagged, "n");


### PR DESCRIPTION
Summary
-------
- fix overly-greedy matching in calculateTagContent

Local Tests Performed
---------------------
- [x] checked select description of Blind Avarice

Issue
-----
Closes #597