### PR TITLE
#493: fix AoE causing double defeat message

### DIFF
--- a/Source/Buttons/join.js
+++ b/Source/Buttons/join.js
@@ -3,7 +3,7 @@ const Button = require('../../Classes/Button.js');
 const Delver = require('../../Classes/Delver.js');
 const { maxDelverCount, ZERO_WIDTH_WHITESPACE } = require("../../constants.js");
 const { isSponsor } = require('../../helpers.js');
-const { getGuild } = require('../guildDAO.js');
+const { getGuild, setGuild } = require('../guildDAO.js');
 const { getAdventure, setAdventure, fetchRecruitMessage } = require("./../adventureDAO.js");
 
 const customId = "join";
@@ -51,6 +51,7 @@ module.exports = new Button(customId,
 		adventure.gainGold(50);
 		setAdventure(adventure);
 		guildProfile.adventuring.add(interaction.user.id);
+		setGuild(guildProfile);
 
 		// Welcome player to thread
 		let thread = interaction.client.guilds.resolve(guildId).channels.resolve(adventureId);

--- a/Source/Commands/delve.js
+++ b/Source/Commands/delve.js
@@ -5,7 +5,7 @@ const Delver = require('../../Classes/Delver.js');
 const { setAdventure } = require('../adventureDAO.js');
 const { getChallenge } = require('../Challenges/_challengeDictionary.js');
 const { elementsList, getColor } = require('../elementHelpers.js');
-const { getGuild } = require('../guildDAO.js');
+const { getGuild, setGuild } = require('../guildDAO.js');
 const { prerollBoss } = require('../labyrinths/_labyrinthDictionary.js');
 const { SAFE_DELIMITER } = require("../../constants.js");
 const { isSponsor, generateRandomNumber } = require('./../../helpers.js');
@@ -58,6 +58,7 @@ module.exports.execute = (interaction) => {
 						});
 						adventure.delvers.push(new Delver(interaction.user.id, interaction.member.displayName, thread.id));
 						guildProfile.adventuring.add(interaction.user.id);
+						setGuild(guildProfile);
 
 						let options = [{ label: "None", description: "Deselect previously selected challenges", value: "None" }];
 						["Can't Hold All this Value", "Restless", "Rushing"].forEach(challengeName => {

--- a/Source/Enemies/bloodtailhawk.js
+++ b/Source/Enemies/bloodtailhawk.js
@@ -11,11 +11,11 @@ module.exports = new Enemy("Bloodtail Hawk")
 	.setStaggerThreshold(1)
 	.setCritBonus(30);
 
-function rakeEffect([target], user, isCrit, adventure) {
+function rakeEffect(targets, user, isCrit, adventure) {
 	let damage = 50;
 	if (isCrit) {
 		damage *= 2;
 	}
 	addModifier(target, { name: "Stagger", stacks: 1 });
-	return dealDamage(target, user, damage, false, user.element, adventure);
+	return dealDamage(targets, user, damage, false, user.element, adventure);
 }

--- a/Source/Enemies/elkemist.js
+++ b/Source/Enemies/elkemist.js
@@ -36,7 +36,7 @@ function troubleEffect([target], user, isCrit, adventure) {
 	}
 	addModifier(user, { name: "Progress", stacks: 15 + generateRandomNumber(adventure, 16, "battle") });
 	addModifier(target, { name: "Stagger", stacks: 1 });
-	return dealDamage(target, user, damage, false, user.element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, user.element, adventure).then(damageText => {
 		return `An obstacle to potion progress is identified and mitigated; ${damageText}`;
 	})
 }
@@ -47,9 +47,7 @@ function boilEffect(targets, user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= 2;
 	}
-	return Promise.all(
-		targets.map(target => dealDamage(target, user, damage, false, "Fire", adventure))
-	).then(results => results.join(" "));
+	return dealDamage(targets, user, damage, false, "Fire", adventure);
 }
 
 function bubbleEffect(targets, user, isCrit, adventure) {

--- a/Source/Enemies/firearrowfrog.js
+++ b/Source/Enemies/firearrowfrog.js
@@ -28,7 +28,7 @@ function venomCannonEffect([target], user, isCrit, adventure) {
 	} else {
 		addModifier(target, { name: "Poison", stacks: 3 });
 	}
-	return dealDamage(target, user, damage, false, user.element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, user.element, adventure).then(damageText => {
 		return `${target.getName(adventure.room.enemyIdMap)} is Poisoned. ${damageText}`;
 	});
 }

--- a/Source/Enemies/geodetortoise.js
+++ b/Source/Enemies/geodetortoise.js
@@ -17,7 +17,7 @@ function biteEffect([target], user, isCrit, adventure) {
 		damage *= 2;
 	}
 	addModifier(target, { name: "Stagger", stacks: 1 });
-	return dealDamage(target, user, damage, false, user.element, adventure);
+	return dealDamage([target], user, damage, false, user.element, adventure);
 }
 
 function crystallizeEffect(targets, user, isCrit, adventure) {

--- a/Source/Enemies/mechabee.js
+++ b/Source/Enemies/mechabee.js
@@ -30,7 +30,7 @@ function stingEffect([target], user, isCrit, adventure) {
 	} else {
 		addModifier(target, { name: "Poison", stacks: 2 });
 	}
-	return dealDamage(target, user, 10, false, user.element, adventure);
+	return dealDamage([target], user, 10, false, user.element, adventure);
 }
 
 function barrelRollEffect(targets, user, isCrit, adventure) {
@@ -54,11 +54,9 @@ function selfDestructEffect(targets, user, isCrit, adventure) {
 		damage *= 2;
 	}
 	user.hp = 0;
+	targets.map(target => {
+		addModifier(target, { name: "Stagger", stacks: 1 });
+	})
 
-	return Promise.all(
-		targets.map(target => {
-			addModifier(target, { name: "Stagger", stacks: 1 });
-			return dealDamage(target, user, damage, false, user.element, adventure);
-		})
-	).then(results => results.join(" "));
+	return dealDamage(targets, user, damage, false, user.element, adventure);
 }

--- a/Source/Enemies/ooze.js
+++ b/Source/Enemies/ooze.js
@@ -17,7 +17,7 @@ function tackleEffect([target], user, isCrit, adventure) {
 		damage *= 2;
 	}
 	addModifier(target, { name: "Stagger", stacks: 1 });
-	return dealDamage(target, user, damage, false, user.element, adventure);
+	return dealDamage([target], user, damage, false, user.element, adventure);
 }
 
 function goopSprayEffect([target], user, isCrit, adventure) {

--- a/Source/Enemies/royalslime.js
+++ b/Source/Enemies/royalslime.js
@@ -32,12 +32,10 @@ function rollingTackleEffect(targets, user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= 2;
 	}
-	return Promise.all(
-		targets.map(target => {
-			addModifier(target, { name: "Stagger", stacks: 1 });
-			return dealDamage(target, user, damage, false, user.element, adventure);
-		})
-	).then(results => results.join(" "));
+	targets.map(target => {
+		addModifier(target, { name: "Stagger", stacks: 1 });
+	})
+	return dealDamage(targets, user, damage, false, user.element, adventure);
 }
 
 function goopDelugeEffect(targets, user, isCrit, adventure) {
@@ -59,7 +57,7 @@ function toxicSpikeShotEffect([target], user, isCrit, adventure) {
 	}
 	addModifier(target, { name: "Stagger", stacks: 1 });
 	addModifier(target, { name: "Poison", stacks: 2 });
-	return dealDamage(target, user, damage, false, user.element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, user.element, adventure).then(damageText => {
 		return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Poisoned.`;
 	});
 }

--- a/Source/Enemies/slime.js
+++ b/Source/Enemies/slime.js
@@ -17,7 +17,7 @@ function tackleEffect([target], user, isCrit, adventure) {
 		damage *= 2;
 	}
 	addModifier(target, { name: "Stagger", stacks: 1 });
-	return dealDamage(target, user, damage, false, adventure.element, adventure);
+	return dealDamage([target], user, damage, false, adventure.element, adventure);
 }
 
 function goopSprayEffect([target], user, isCrit, adventure) {

--- a/Source/Enemies/treasureelemental.js
+++ b/Source/Enemies/treasureelemental.js
@@ -34,7 +34,7 @@ function guardingSlamEffect([target], user, isCrit, adventure) {
 	}
 	addBlock(user, block);
 	removeModifier(user, { name: "Stagger", stacks: 1 });
-	return dealDamage(target, user, 100, false, user.element, adventure).then(damageText => {
+	return dealDamage([target], user, 100, false, user.element, adventure).then(damageText => {
 		return `It prepares to Block and ${damageText}`;
 	});
 }

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -19,7 +19,7 @@ const { getTurnDecrement } = require("./Modifiers/_modifierDictionary.js");
 
 const { clearBlock, removeModifier } = require("./combatantDAO.js");
 const { spawnEnemy } = require("./enemyDAO.js");
-const { getGuild } = require("./guildDAO.js");
+const { getGuild, setGuild } = require("./guildDAO.js");
 const { resolveMove } = require("./moveDAO.js");
 const { renderRoom, updateRoomHeader } = require("./roomDAO.js");
 const { getEquipmentProperty } = require("./equipment/_equipmentDictionary.js");
@@ -41,12 +41,8 @@ exports.loadAdventures = async function () {
 				loaded++;
 				// Cast delvers into Delver class
 				let castDelvers = [];
-				let guildProfile = getGuild(adventure.guildId);
 				for (let delver of adventure.delvers) {
 					castDelvers.push(Object.assign(new Delver(), delver));
-					if (!guildProfile.adventuring.has(delver.id)) {
-						guildProfile.adventuring.add(delver.id);
-					}
 				}
 				adventure.delvers = castDelvers;
 
@@ -491,5 +487,8 @@ exports.completeAdventure = function (adventure, thread, endState, descriptionOv
 
 	adventure.state = endState;
 	exports.setAdventure(adventure);
+	const guildProfile = getGuild(thread.guild.id);
+	adventure.delvers.forEach(delver => guildProfile.adventuring.delete(delver.id));
+	setGuild(guildProfile);
 	return renderRoom(adventure, thread, descriptionOverride);
 }

--- a/Source/consumables/explosionpotion.js
+++ b/Source/consumables/explosionpotion.js
@@ -10,7 +10,5 @@ module.exports = new ConsumableTemplate("Explosion Potion", "Deal 75 damage to a
 
 function effect(targets, user, isCrit, adventure) {
 	// 75 damage
-	return Promise.all(
-		targets.map(target => dealDamage(target, user, 75, false, "Untyped", adventure))
-	).then(results => results.join(" "))
+	return dealDamage(targets, user, 75, false, "Untyped", adventure);
 }

--- a/Source/equipment/-punch.js
+++ b/Source/equipment/-punch.js
@@ -19,5 +19,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/battleaxe-base.js
+++ b/Source/equipment/battleaxe-base.js
@@ -22,7 +22,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, exposed);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is Exposed.`
 	});
 }

--- a/Source/equipment/battleaxe-prideful.js
+++ b/Source/equipment/battleaxe-prideful.js
@@ -22,7 +22,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, exposed);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is Exposed.`;
 	});
 }

--- a/Source/equipment/battleaxe-thick.js
+++ b/Source/equipment/battleaxe-thick.js
@@ -22,7 +22,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, exposed);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is Exposed.`
 	});
 }

--- a/Source/equipment/battleaxe-thirsting.js
+++ b/Source/equipment/battleaxe-thirsting.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, exposed);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (target.hp < 1) {
 			damageText += gainHealth(user, healing, adventure);
 		}

--- a/Source/equipment/bow-base.js
+++ b/Source/equipment/bow-base.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/bow-evasive.js
+++ b/Source/equipment/bow-evasive.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, evade);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is ready to Evade.`;
 	});
 }

--- a/Source/equipment/bow-hunters.js
+++ b/Source/equipment/bow-hunters.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (target.hp < 1) {
 			adventure.gainGold(bonusBounty);
 			damageText += ` ${user.getName(adventure.room.enemyIdMap)} forages ${bonusBounty}g of hunting trophies.`;

--- a/Source/equipment/bow-mercurial.js
+++ b/Source/equipment/bow-mercurial.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/censer-base.js
+++ b/Source/equipment/censer-base.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 		damage += bonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (isCrit && target.hp > 0) {
 			addModifier(target, slow);
 			return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Slowed.`;

--- a/Source/equipment/censer-fatesealing.js
+++ b/Source/equipment/censer-fatesealing.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 		damage += bonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (isCrit && target.hp > 0) {
 			addModifier(target, slow);
 			addModifier(target, stasis);

--- a/Source/equipment/censer-thick.js
+++ b/Source/equipment/censer-thick.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 		damage += bonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (isCrit && target.hp > 0) {
 			addModifier(target, slow);
 			return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Slowed.`;

--- a/Source/equipment/censer-tormenting.js
+++ b/Source/equipment/censer-tormenting.js
@@ -27,7 +27,7 @@ function effect([target], user, isCrit, adventure) {
 	if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 		damage += bonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (isCrit && target.hp > 0) {
 			addModifier(target, slow);
 			return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Slowed and their other debuffs are duplicated.`;

--- a/Source/equipment/certainvictory-base.js
+++ b/Source/equipment/certainvictory-base.js
@@ -22,7 +22,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, powerUp);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${damageText} ${user.getName(adventure.room.enemyIdMap)} is Powered Up.`;
 	});
 }

--- a/Source/equipment/certainvictory-hunters.js
+++ b/Source/equipment/certainvictory-hunters.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, powerUp);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (target.hp < 1) {
 			adventure.gainGold(bounty);
 			damageText += ` ${user.getName(adventure.room.enemyIdMap)} gains ${bounty}g of victory spoils.`;

--- a/Source/equipment/certainvictory-lethal.js
+++ b/Source/equipment/certainvictory-lethal.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, powerUp);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${damageText} ${user.getName(adventure.room.enemyIdMap)} is Powered Up.`;
 	});
 }

--- a/Source/equipment/certainvictory-reckless.js
+++ b/Source/equipment/certainvictory-reckless.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	}
 	addModifier(user, powerUp);
 	addModifier(user, exposed);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${damageText} ${user.getName(adventure.room.enemyIdMap)} is Powered Up and Exposed.`;
 	});
 }

--- a/Source/equipment/daggers-base.js
+++ b/Source/equipment/daggers-base.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/daggers-sharpened.js
+++ b/Source/equipment/daggers-sharpened.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/daggers-slowing.js
+++ b/Source/equipment/daggers-slowing.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(target, slow);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Slowed.`;
 	});
 }

--- a/Source/equipment/daggers-sweeping.js
+++ b/Source/equipment/daggers-sweeping.js
@@ -12,18 +12,16 @@ module.exports = new EquipmentTemplate("Sweeping Daggers", "Strike all foes for 
 
 function effect(targets, user, isCrit, adventure) {
 	let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
-	return Promise.all(
-		targets.map(target => {
-			if (target.hp < 1) {
-				return "";
-			}
-			if (user.element === element) {
-				addModifier(target, elementStagger);
-			}
-			if (isCrit) {
-				damage *= critBonus;
-			}
-			return dealDamage(target, user, damage, false, element, adventure);
-		})
-	).then(results => results.filter(result => Boolean(result)).join(" "));
+	targets.map(target => {
+		if (target.hp < 1) {
+			return "";
+		}
+		if (user.element === element) {
+			addModifier(target, elementStagger);
+		}
+		if (isCrit) {
+			damage *= critBonus;
+		}
+	})
+	return dealDamage(targets, user, damage, false, element, adventure);
 }

--- a/Source/equipment/firecracker-base.js
+++ b/Source/equipment/firecracker-base.js
@@ -24,6 +24,6 @@ function effect(targets, user, isCrit, adventure) {
 		if (user.element === element) {
 			addModifier(target, elementStagger);
 		}
-		return dealDamage(target, user, damage, false, element, adventure);
+		return dealDamage([target], user, damage, false, element, adventure);
 	})).then(results => results.filter(result => Boolean(result)).join(" "));
 }

--- a/Source/equipment/firecracker-double.js
+++ b/Source/equipment/firecracker-double.js
@@ -25,7 +25,7 @@ function effect(targets, user, isCrit, adventure) {
 			if (user.element === element) {
 				addModifier(target, elementStagger);
 			}
-			return dealDamage(target, user, damage, false, element, adventure);
+			return dealDamage([target], user, damage, false, element, adventure);
 		})
 	).then(results => results.filter(result => Boolean(result)).join(" "));
 }

--- a/Source/equipment/firecracker-mercurial.js
+++ b/Source/equipment/firecracker-mercurial.js
@@ -25,7 +25,7 @@ function effect(targets, user, isCrit, adventure) {
 			if (user.element === element) {
 				addModifier(target, elementStagger);
 			}
-			return dealDamage(target, user, damage, false, user.element, adventure);
+			return dealDamage([target], user, damage, false, user.element, adventure);
 		})
 	).then(results => results.filter(result => Boolean(result)).join(" "));
 }

--- a/Source/equipment/firecracker-toxic.js
+++ b/Source/equipment/firecracker-toxic.js
@@ -26,7 +26,7 @@ function effect(targets, user, isCrit, adventure) {
 				addModifier(target, elementStagger);
 			}
 			addModifier(target, poison);
-			return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+			return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 				return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Poisoned.`;
 			});
 		})

--- a/Source/equipment/lance-accelerating.js
+++ b/Source/equipment/lance-accelerating.js
@@ -25,7 +25,7 @@ function effect([target], user, isCrit, adventure) {
 		damage += powerUpStacks;
 	}
 	addModifier(user, quicken);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is Quickened.`;
 	});
 }

--- a/Source/equipment/lance-base.js
+++ b/Source/equipment/lance-base.js
@@ -24,5 +24,5 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 		damage += powerUpStacks;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/lance-piercing.js
+++ b/Source/equipment/lance-piercing.js
@@ -24,5 +24,5 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 		damage += powerUpStacks;
 	}
-	return dealDamage(target, user, damage, true, element, adventure);
+	return dealDamage([target], user, damage, true, element, adventure);
 }

--- a/Source/equipment/lance-vigilant.js
+++ b/Source/equipment/lance-vigilant.js
@@ -27,7 +27,7 @@ function effect([target], user, isCrit, adventure) {
 	}
 	addBlock(user, block);
 	addModifier(user, vigilance);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} gains Vigilance`;
 	});
 }

--- a/Source/equipment/lifedrain-base.js
+++ b/Source/equipment/lifedrain-base.js
@@ -22,5 +22,5 @@ async function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		healing *= critBonus;
 	}
-	return `${await dealDamage(target, user, damage, false, element, adventure)} ${gainHealth(user, healing, adventure)}`;
+	return `${await dealDamage([target], user, damage, false, element, adventure)} ${gainHealth(user, healing, adventure)}`;
 }

--- a/Source/equipment/lifedrain-flanking.js
+++ b/Source/equipment/lifedrain-flanking.js
@@ -22,7 +22,7 @@ async function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		healing *= critBonus;
 	}
-	let damageText = await dealDamage(target, user, damage, false, element, adventure);
+	let damageText = await dealDamage([target], user, damage, false, element, adventure);
 	addModifier(target, exposed);
 	return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Exposed. ${gainHealth(user, healing, adventure)}`;
 }

--- a/Source/equipment/lifedrain-reactive.js
+++ b/Source/equipment/lifedrain-reactive.js
@@ -26,5 +26,5 @@ async function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		healing *= critBonus;
 	}
-	return `${await dealDamage(target, user, damage, false, element, adventure)} ${gainHealth(user, healing, adventure)}`;
+	return `${await dealDamage([target], user, damage, false, element, adventure)} ${gainHealth(user, healing, adventure)}`;
 }

--- a/Source/equipment/lifedrain-urgent.js
+++ b/Source/equipment/lifedrain-urgent.js
@@ -23,5 +23,5 @@ async function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		healing *= critBonus;
 	}
-	return `${await dealDamage(target, user, damage, false, element, adventure)} ${gainHealth(user, healing, adventure)}`;
+	return `${await dealDamage([target], user, damage, false, element, adventure)} ${gainHealth(user, healing, adventure)}`;
 }

--- a/Source/equipment/scythe-base.js
+++ b/Source/equipment/scythe-base.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		hpThreshold *= critBonus;
 	}
 	if (target.hp > hpThreshold) {
-		return dealDamage(target, user, damage, false, element, adventure);
+		return dealDamage([target], user, damage, false, element, adventure);
 	} else {
 		target.hp = 0;
 		return `${target.getName(adventure.room.enemyIdMap)} meets the reaper.`;

--- a/Source/equipment/scythe-lethal.js
+++ b/Source/equipment/scythe-lethal.js
@@ -24,7 +24,7 @@ function effect([target], user, isCrit, adventure) {
 		hpThreshold *= critBonus;
 	}
 	if (target.hp > hpThreshold) {
-		return dealDamage(target, user, damage, false, element, adventure);
+		return dealDamage([target], user, damage, false, element, adventure);
 	} else {
 		target.hp = 0;
 		return `${target.getName(adventure.room.enemyIdMap)} meets the reaper.`;

--- a/Source/equipment/scythe-piercing.js
+++ b/Source/equipment/scythe-piercing.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 		hpThreshold *= critBonus;
 	}
 	if (target.hp > hpThreshold) {
-		return dealDamage(target, user, damage, true, element, adventure);
+		return dealDamage([target], user, damage, true, element, adventure);
 	} else {
 		target.hp = 0;
 		return `${target.getName(adventure.room.enemyIdMap)} meets the reaper.`;

--- a/Source/equipment/scythe-toxic.js
+++ b/Source/equipment/scythe-toxic.js
@@ -24,7 +24,7 @@ function effect([target], user, isCrit, adventure) {
 	}
 	if (target.hp > hpThreshold) {
 		addModifier(target, poison);
-		return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+		return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 			return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Poisoned.`;
 		});
 	} else {

--- a/Source/equipment/shortsword-accelerating.js
+++ b/Source/equipment/shortsword-accelerating.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	}
 	addModifier(user, exposed);
 	addModifier(user, quicken);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		addModifier(target, exposed);
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is Quickened and Exposed.`;
 	});

--- a/Source/equipment/shortsword-base.js
+++ b/Source/equipment/shortsword-base.js
@@ -22,7 +22,7 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(user, exposed);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		addModifier(target, exposed);
 		return `${damageText} ${user.getName(adventure.room.enemyIdMap)} is Exposed.`;
 	});

--- a/Source/equipment/shortsword-toxic.js
+++ b/Source/equipment/shortsword-toxic.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	}
 	addModifier(user, exposed);
 	addModifier(target, poison);
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		addModifier(target, exposed);
 		return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Poisoned. ${user.getName(adventure.room.enemyIdMap)} is Exposed.`;
 	});

--- a/Source/equipment/sickle-base.js
+++ b/Source/equipment/sickle-base.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/sickle-hunters.js
+++ b/Source/equipment/sickle-hunters.js
@@ -23,7 +23,7 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (target.hp < 1) {
 			adventure.gainGold(bonusBounty);
 			damageText += ` ${user.getName(adventure.room.enemyIdMap)} harvests ${bonusBounty}g of alchemical reagents.`;

--- a/Source/equipment/sickle-sharpened.js
+++ b/Source/equipment/sickle-sharpened.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/sickle-toxic.js
+++ b/Source/equipment/sickle-toxic.js
@@ -22,7 +22,7 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure).then(damageText => {
+	return dealDamage([target], user, damage, false, element, adventure).then(damageText => {
 		if (target.hp > 0) {
 			addModifier(target, poison);
 			return `${damageText} ${target.getName(adventure.room.enemyIdMap)} is Poisoned.`;

--- a/Source/equipment/spear-base.js
+++ b/Source/equipment/spear-base.js
@@ -21,5 +21,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		addModifier(target, critStagger);
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/spear-lethal.js
+++ b/Source/equipment/spear-lethal.js
@@ -22,5 +22,5 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 		addModifier(target, critStagger);
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/spear-reactive.js
+++ b/Source/equipment/spear-reactive.js
@@ -25,5 +25,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		addModifier(target, critStagger);
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/spear-sweeping.js
+++ b/Source/equipment/spear-sweeping.js
@@ -11,19 +11,17 @@ module.exports = new EquipmentTemplate("Sweeping Spear", "Strike all foes for @{
 
 function effect(targets, user, isCrit, adventure) {
 	let { element, modifiers: [elementStagger, critStagger], damage } = module.exports;
-	return Promise.all(
-		targets.map(target => {
-			if (target.hp < 1) {
-				return "";
-			}
+	targets.map(target => {
+		if (target.hp < 1) {
+			return "";
+		}
 
-			if (user.element === element) {
-				addModifier(target, elementStagger);
-			}
-			if (isCrit) {
-				addModifier(target, critStagger);
-			}
-			return dealDamage(target, user, damage, false, element, adventure);
-		})
-	).then(results => results.filter(result => Boolean(result)).join(" "));
+		if (user.element === element) {
+			addModifier(target, elementStagger);
+		}
+		if (isCrit) {
+			addModifier(target, critStagger);
+		}
+	})
+	return dealDamage(targets, user, damage, false, element, adventure);
 }

--- a/Source/equipment/warhammer-base.js
+++ b/Source/equipment/warhammer-base.js
@@ -25,5 +25,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/equipment/warhammer-piercing.js
+++ b/Source/equipment/warhammer-piercing.js
@@ -25,5 +25,5 @@ function effect([target], user, isCrit, adventure) {
 	if (isCrit) {
 		damage *= critBonus;
 	}
-	return dealDamage(target, user, damage, true, element, adventure);
+	return dealDamage([target], user, damage, true, element, adventure);
 }

--- a/Source/equipment/warhammer-slowing.js
+++ b/Source/equipment/warhammer-slowing.js
@@ -27,5 +27,5 @@ function effect([target], user, isCrit, adventure) {
 		damage *= critBonus;
 	}
 	addModifier(target, slow);
-	return dealDamage(target, user, damage, false, element, adventure);
+	return dealDamage([target], user, damage, false, element, adventure);
 }

--- a/Source/guildDAO.js
+++ b/Source/guildDAO.js
@@ -12,7 +12,7 @@ exports.loadGuilds = async function () {
 	if (fs.existsSync(filePath)) {
 		const guildProfiles = require(requirePath);
 		guildProfiles.forEach(guildProfile => {
-			guildProfile.adventuring = new Set();
+			guildProfile.adventuring = new Set(guildProfile.adventurerIds);
 			guildDictionary.set(guildProfile.id, guildProfile);
 		})
 		return `${guildProfiles.length} guilds loaded`;
@@ -37,5 +37,8 @@ exports.getGuild = function (guildId) {
 
 exports.setGuild = function (guildProfile) {
 	guildDictionary.set(guildProfile.id, guildProfile);
-	ensuredPathSave("./Saves", "guilds.json", JSON.stringify(Array.from((guildDictionary.values()))));
+	ensuredPathSave("./Saves", "guilds.json", JSON.stringify(Array.from((guildDictionary.values())).map(guild => {
+		guild.adventurerIds = Array.from(guild.adventuring.values());
+		return guild;
+	})));
 }

--- a/Source/moveDAO.js
+++ b/Source/moveDAO.js
@@ -104,7 +104,7 @@ exports.resolveMove = async function (move, adventure) {
 
 	const regenStacks = user.getModifierStacks("Regen");
 	if (poisonDamage) {
-		moveText += ` ${await dealDamage(user, null, poisonDamage, true, "Poison", adventure)}`;
+		moveText += ` ${await dealDamage([user], null, poisonDamage, true, "Poison", adventure)}`;
 	} else if (regenStacks) {
 		moveText += ` ${gainHealth(user, regenStacks * 10, adventure)}`;
 	}


### PR DESCRIPTION
Summary
-------
- fix AoE causing double defeat messages by changing dealDamage to take target array
- fixed adventureDAO setting guildProfile.adventuring instead of guildDAO

Local Tests Performed
---------------------
- [x] got killed by Elkemist's Boil a few times

Issue
-----
Closes #493