### PR TITLE
#598: fix missing component clear on round messages where party is all stunned

### DIFF
--- a/Source/Enemies/bloodtailhawk.js
+++ b/Source/Enemies/bloodtailhawk.js
@@ -11,11 +11,11 @@ module.exports = new Enemy("Bloodtail Hawk")
 	.setStaggerThreshold(1)
 	.setCritBonus(30);
 
-function rakeEffect(targets, user, isCrit, adventure) {
+function rakeEffect([target], user, isCrit, adventure) {
 	let damage = 50;
 	if (isCrit) {
 		damage *= 2;
 	}
 	addModifier(target, { name: "Stagger", stacks: 1 });
-	return dealDamage(targets, user, damage, false, user.element, adventure);
+	return dealDamage([target], user, damage, false, user.element, adventure);
 }

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -267,7 +267,6 @@ exports.endRoom = function (roomType, thread) {
 exports.newRound = function (adventure, thread, lastRoundText) {
 	// Increment round and clear last round's components
 	adventure.room.round++;
-	clearComponents(adventure.messageIds.battleRound, thread.messages);
 
 	// Logistics for Next Round
 	let teams = {
@@ -346,6 +345,7 @@ exports.newRound = function (adventure, thread, lastRoundText) {
 			updateRoomHeader(adventure, message);
 			adventure.messageIds.battleRound = message.id;
 		} else {
+			clearComponents(message.id, thread.messages);
 			exports.endRound(adventure, thread);
 		}
 		exports.setAdventure(adventure);
@@ -357,6 +357,8 @@ exports.newRound = function (adventure, thread, lastRoundText) {
  * @param {ThreadChannel} thread
  */
 exports.endRound = async function (adventure, thread) {
+	clearComponents(adventure.messageIds.battleRound, thread.messages);
+
 	// Generate Reactive Moves by Enemies
 	adventure.room.enemies.forEach((enemy, index) => {
 		if (enemy.archetype === "@{clone}") {

--- a/Source/combatantDAO.js
+++ b/Source/combatantDAO.js
@@ -68,7 +68,6 @@ exports.dealDamage = async function (targets, user, damage, isUnblockable, eleme
 					if (target.team === "delver") {
 						target.hp = target.maxHp;
 						adventure.lives = Math.max(adventure.lives - 1, 0);
-						console.log(adventure.lives);
 						damageText += ` *${targetName} has died*${adventure.lives > 0 ? " and been revived" : ""}.`;
 					} else {
 						target.hp = 0;


### PR DESCRIPTION
Summary
-------
- fix missing component clear on round messages the party is stunned out of
- fix crash on hawk's rake

Local Tests Performed
---------------------
- [x] tested against geode tortoise fight with artificially lowered stagger threshold, round when player was stunned have components removed
- [x] hawks can use rake without crashing the bot

Issue
-----
Closes #598