### PR TITLE
#503: rename /delver-stats to /inspect-self

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,7 @@
    - Anyone can now pick a challenge at a rest site, make sure to discuss with the party!
    - Start of adventure now has a "Ready!" button instead of a confirmation after everyone's picked an archetype
    - Anyone can now `/give-up`
+- Renamed `/delver-stats` to `/inspect-self` to match the button that does the same thing in combat
 
 #### Prophets of the Labyrinth Version 0.10.0:
 - Added **Consumables**: these resources can be used by any party member during combat at priority speed

--- a/Source/Buttons/inspectself.js
+++ b/Source/Buttons/inspectself.js
@@ -1,6 +1,6 @@
 const Button = require('../../Classes/Button.js');
 const { getAdventure } = require('../adventureDAO.js');
-const { delverStatsPayload } = require('../equipmentDAO.js');
+const { inspectSelfPayload } = require('../equipmentDAO.js');
 
 const customId = "inspectself";
 module.exports = new Button(customId,
@@ -12,7 +12,7 @@ module.exports = new Button(customId,
 			interaction.reply({ content: "This adventure isn't active or you aren't participating in it.", ephemeral: true });
 			return;
 		}
-		interaction.reply(delverStatsPayload(delver, adventure.getEquipmentCapacity()))
+		interaction.reply(inspectSelfPayload(delver, adventure.getEquipmentCapacity()))
 			.catch(console.error);
 	}
 );

--- a/Source/Commands/_commandDictionary.js
+++ b/Source/Commands/_commandDictionary.js
@@ -2,7 +2,7 @@ const CommandSet = require('../../Classes/CommandSet.js');
 
 // A maximum of 25 command sets are supported by /commands to conform with MessageEmbed limit of 25 fields
 exports.commandSets = [
-	new CommandSet("Game Commands", "Here are the commands you'll use when playing Prophets of the Labyrinth", false, ["delve.js", "invite.js", "party-stats.js", "delver-stats.js", "ping.js", "give-up.js"]),
+	new CommandSet("Game Commands", "Here are the commands you'll use when playing Prophets of the Labyrinth", false, ["delve.js", "invite.js", "party-stats.js", "inspect-self.js", "ping.js", "give-up.js"]),
 	new CommandSet("Informational Commands", "Use these commands to look up information about Prophets of the Labyrinth!", false, ["manual.js", "armory.js", "consumable-info.js", "commands.js", "stats.js", "feedback.js", "version.js", "support.js"]),
 	new CommandSet("Configuration Commands", "These commands change how the bot operates on your server. They require bot management permission (a role above the bot's roles).", true, ["reset.js"]),
 	// moderationCommands

--- a/Source/Commands/inspect-self.js
+++ b/Source/Commands/inspect-self.js
@@ -1,8 +1,8 @@
 const Command = require('../../Classes/Command.js');
 const { getAdventure } = require('../adventureDAO.js');
-const { delverStatsPayload } = require('../equipmentDAO.js');
+const { inspectSelfPayload } = require('../equipmentDAO.js');
 
-const customId = "delver-stats";
+const customId = "inspect-self";
 const options = [];
 module.exports = new Command(customId, "Get your adventure-specific stats for the thread's adventure", false, false, options);
 
@@ -12,7 +12,7 @@ module.exports.execute = (interaction) => {
 	if (adventure) {
 		const delver = adventure.delvers.find(delver => delver.id === interaction.user.id);
 		if (delver) {
-			interaction.reply(delverStatsPayload(delver, adventure.getEquipmentCapacity()))
+			interaction.reply(inspectSelfPayload(delver, adventure.getEquipmentCapacity()))
 				.catch(console.error);
 		} else {
 			interaction.reply({ content: "You are not a part of this adventure.", ephemeral: true });

--- a/Source/equipmentDAO.js
+++ b/Source/equipmentDAO.js
@@ -3,7 +3,7 @@ const { getEquipmentProperty, buildEquipmentDescription } = require("./equipment
 const { isBuff, isDebuff, isNonStacking } = require("./Modifiers/_modifierDictionary");
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { SAFE_DELIMITER, MAX_BUTTONS_PER_ROW } = require("../constants.js");
-const { ordinalSuffixEN } = require("../helpers.js");
+const { ordinalSuffixEN, generateTextBar } = require("../helpers.js");
 
 /** Seen in target selection embeds and /inspect-self equipment fields contain nearly all information about the equipment they represent
  * @param {string} equipmentName
@@ -11,7 +11,8 @@ const { ordinalSuffixEN } = require("../helpers.js");
  * @returns {import("discord.js").EmbedField} contents for a message embed field [heading, body]
  */
 exports.equipmentToEmbedField = function (equipmentName, uses) {
-	const usesText = uses === Infinity ? "∞ uses" : `${uses}/${getEquipmentProperty(equipmentName, "maxUses")} uses`;
+	const maxUses = getEquipmentProperty(equipmentName, "maxUses");
+	const usesText = uses === Infinity ? "∞ uses" : `${generateTextBar(uses, maxUses, maxUses)} ${uses}/${maxUses} uses`;
 	return {
 		name: `${equipmentName} ${getEmoji(getEquipmentProperty(equipmentName, "element"))} (${usesText})`,
 		value: buildEquipmentDescription(equipmentName, true)
@@ -23,10 +24,10 @@ exports.equipmentToEmbedField = function (equipmentName, uses) {
  * @param {number} equipmentCapacity
  * @returns {MessageOptions}
  */
-exports.delverStatsPayload = function (delver, equipmentCapacity) {
+exports.inspectSelfPayload = function (delver, equipmentCapacity) {
 	const embed = new EmbedBuilder().setColor(getColor(delver.element))
-		.setTitle(delver.getName())
-		.setDescription(`HP: ${delver.hp}/${delver.maxHp}\nPredicts: ${delver.predict}\nYour ${getEmoji(delver.element)} moves add 1 Stagger to enemies and remove 1 Stagger from allies.`)
+		.setTitle(`${delver.getName()} the ${delver.archetype}`)
+		.setDescription(`HP: ${generateTextBar(delver.hp, delver.maxHp, 11)} ${delver.hp}/${delver.maxHp}\nPredicts: ${delver.predict}\nYour ${getEmoji(delver.element)} moves add 1 Stagger to enemies and remove 1 Stagger from allies.`)
 		.setFooter({ text: "Imaginary Horizons Productions", iconURL: "https://cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png" });
 	if (delver.block > 0) {
 		embed.addFields({ name: "Block", value: delver.block.toString() })


### PR DESCRIPTION
Summary
-------
- renamed /delver-stats to /inspect-self to match button in combat with same functionality
- added player archetype to inspect self embed
- added hp ratio bar and gear durability bars to inspect self embed

Local Tests Performed
---------------------
- [x] found that button and slash command are using the same generator function, used button to test output

Issue
-----
Closes #503