### PR TITLE
Add autocomplete for armory and consumable-info

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,7 @@
    - Start of adventure now has a "Ready!" button instead of a confirmation after everyone's picked an archetype
    - Anyone can now `/give-up`
 - Renamed `/delver-stats` to `/inspect-self` to match the button that does the same thing in combat
+- Updated `armory` and `consumable-info` commands to now utilize Discord autocomplete
 
 #### Prophets of the Labyrinth Version 0.10.0:
 - Added **Consumables**: these resources can be used by any party member during combat at priority speed

--- a/Classes/Command.js
+++ b/Classes/Command.js
@@ -12,11 +12,16 @@ module.exports = class Command {
 			.setDescription(descriptionInput);
 		optionsInput.forEach(option => {
 			this.data[`add${option.type}Option`](built => {
-				built.setName(option.name).setDescription(option.description).setRequired(option.required);
-				if (option.choices === null || option.choices === undefined) {
+				built.setName(option.name)
+					.setDescription(option.description)
+					.setRequired(option.required);
+				if (option.autocomplete === true) {
+					built.setAutocomplete(true);
+				}
+				else if (option.choices === null || option.choices === undefined) {
 					throw `Error: ${this.nameInput} (${descriptionInput}) ${option.type} Option was nullish.`;
 				}
-				if (option.choices.length) {
+				else if (option.choices.length) {
 					built.addChoices(...option.choices);
 				}
 				return built;

--- a/Source/Commands/armory.js
+++ b/Source/Commands/armory.js
@@ -1,11 +1,11 @@
 const Command = require('../../Classes/Command.js');
 const { embedTemplate } = require('../../helpers.js');
 const { getColor } = require('../elementHelpers.js');
-const { equipmentExists, buildEquipmentDescription, getEquipmentProperty } = require('../equipment/_equipmentDictionary.js');
+const { equipNames, equipmentExists, buildEquipmentDescription, getEquipmentProperty } = require('../equipment/_equipmentDictionary.js');
 
 const id = "armory";
 const options = [
-	{ type: "String", name: "equipment-name", description: "The name of the equipment (case-sensitive)", required: true, choices: [] }
+	{ type: "String", name: "equipment-name", description: "The name of the equipment (case-sensitive)", required: true, autocomplete: true, choices: [] }
 ];
 module.exports = new Command(id, "Look up the stats on a type of equipment", false, false, options);
 
@@ -25,3 +25,5 @@ module.exports.execute = (interaction) => {
 		interaction.reply({ content: `Stats on **${equipmentName}** could not be found. Check for typos!`, ephemeral: true });
 	}
 }
+
+module.exports["autocomplete_equipment-name"] = equipNames;

--- a/Source/Commands/armory.js
+++ b/Source/Commands/armory.js
@@ -26,4 +26,6 @@ module.exports.execute = (interaction) => {
 	}
 }
 
-module.exports["autocomplete_equipment-name"] = equipNames;
+module.exports.autocomplete = {
+	"equipment-name": equipNames
+};

--- a/Source/Commands/consumable-info.js
+++ b/Source/Commands/consumable-info.js
@@ -1,12 +1,12 @@
 const Command = require('../../Classes/Command.js');
 const { embedTemplate } = require('../../helpers.js');
 const { getAdventure } = require('../adventureDAO.js');
-const { consumableExists, getConsumable } = require('../consumables/_consumablesDictionary.js');
+const { consumableNames, consumableExists, getConsumable } = require('../consumables/_consumablesDictionary.js');
 const { getColor } = require('../elementHelpers.js');
 
 const id = "consumable-info";
 const options = [
-	{ type: "String", name: "consumable-name", description: "The name of the consumable (case-sensitive)", required: true, choices: [] }
+	{ type: "String", name: "consumable-name", description: "The name of the consumable (case-sensitive)", required: true, autocomplete: true, choices: [] }
 ];
 module.exports = new Command(id, "Look up the info on a consumable", false, false, options);
 
@@ -28,3 +28,5 @@ module.exports.execute = (interaction) => {
 		interaction.reply({ content: `Stats on **${consumableName}** could not be found. Check for typos!`, ephemeral: true });
 	}
 }
+
+module.exports["autocomplete_consumable-name"] = consumableNames;

--- a/Source/Commands/consumable-info.js
+++ b/Source/Commands/consumable-info.js
@@ -29,4 +29,6 @@ module.exports.execute = (interaction) => {
 	}
 }
 
-module.exports["autocomplete_consumable-name"] = consumableNames;
+module.exports.autocomplete = {
+	"consumable-name": consumableNames
+};

--- a/Source/consumables/_consumablesDictionary.js
+++ b/Source/consumables/_consumablesDictionary.js
@@ -23,6 +23,8 @@ for (const file of [
 	CONSUMABLES[consumable.name] = consumable;
 }
 
+exports.consumableNames = Object.keys(CONSUMABLES);
+
 /** Checks if a consumable with the given name exists
  * @param {string} consumableName
  * @returns {boolean}

--- a/Source/equipment/_equipmentDictionary.js
+++ b/Source/equipment/_equipmentDictionary.js
@@ -106,6 +106,8 @@ for (const file of [
 	EQUIPMENT[equip.name] = equip;
 };
 
+exports.equipNames = Object.keys(EQUIPMENT);
+
 /** Checks if a type of equipment with the given name exists
  * @param {string} equipmentName
  * @returns {boolean}

--- a/bot.js
+++ b/bot.js
@@ -86,7 +86,7 @@ client.on(Events.ClientReady, () => {
 	})();
 })
 
-client.on(Events.InteractionCreate, interaction => {
+client.on(Events.InteractionCreate, async interaction => {
 	if (interaction.isCommand()) {
 		const { premiumCommand, managerCommand, execute } = getCommand(interaction.commandName);
 		if (!premiumCommand || !getPremiumUsers().includes(interaction.user.id)) {
@@ -100,7 +100,29 @@ client.on(Events.InteractionCreate, interaction => {
 			interaction.reply({ content: `The \`/${interaction.commandName}\` command is a premium command. Use \`/support\` for more information.`, ephemeral: true })
 				.catch(console.error);
 		}
-	} else {
+	} else if (interaction.isAutocomplete()) {
+		const command = getCommand(interaction.commandName);
+		if (!command) {
+			console.error(`No command matching ${interaction.commandName} was found.`);
+			return;
+		}
+		try {
+			const focusedOption = interaction.options.getFocused(true);
+			const acKey = `autocomplete_${focusedOption.name}`;
+			let choices;
+			if (acKey in command) {
+				choices = command[acKey];
+			}
+			else {
+				throw new Error(`export: "${acKey}" not defined for ${interaction.commandName}`)
+			}
+			// return max 25 options that contain current focused text. TODO performance may need to be tuned to keep under 3 seconds as we scale up any lists 
+			await interaction.respond(choices.filter(choice => choice.toLowerCase().includes(focusedOption.value.toLowerCase())).map(n => ({ name: n, value: n })).slice(0, 25));
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	else {
 		const [mainId, ...args] = interaction.customId.split(SAFE_DELIMITER);
 		if (interaction.isButton()) {
 			callButton(mainId, interaction, args);

--- a/bot.js
+++ b/bot.js
@@ -86,7 +86,7 @@ client.on(Events.ClientReady, () => {
 	})();
 })
 
-client.on(Events.InteractionCreate, async interaction => {
+client.on(Events.InteractionCreate, interaction => {
 	if (interaction.isCommand()) {
 		const { premiumCommand, managerCommand, execute } = getCommand(interaction.commandName);
 		if (!premiumCommand || !getPremiumUsers().includes(interaction.user.id)) {
@@ -108,16 +108,16 @@ client.on(Events.InteractionCreate, async interaction => {
 		}
 		try {
 			const focusedOption = interaction.options.getFocused(true);
-			const acKey = `autocomplete_${focusedOption.name}`;
+			const acKey = `${focusedOption.name}`;
 			let choices;
-			if (acKey in command) {
-				choices = command[acKey];
+			if (acKey in command.autocomplete) {
+				choices = command.autocomplete[acKey];
 			}
 			else {
 				throw new Error(`export: "${acKey}" not defined for ${interaction.commandName}`)
 			}
 			// return max 25 options that contain current focused text. TODO performance may need to be tuned to keep under 3 seconds as we scale up any lists 
-			await interaction.respond(choices.filter(choice => choice.toLowerCase().includes(focusedOption.value.toLowerCase())).map(n => ({ name: n, value: n })).slice(0, 25));
+			interaction.respond(choices.filter(choice => choice.toLowerCase().includes(focusedOption.value.toLowerCase())).map(n => ({ name: n, value: n })).slice(0, 25));
 		} catch (error) {
 			console.error(error);
 		}


### PR DESCRIPTION
Summary
-------
Implemented general-purpose autocomplete, and wired armory and consumable-info to use it (leave other commands alone such that new autocomplete clauses don't affect them)

Local Tests Performed
---------------------
tested on armory and consumable-info commands
tested that give-up still works

Issue
-----
Closes #410
