### PR TITLE
#?: labyrinth entity validation

### DIFF
--- a/Source/equipment/potionkit-base.js
+++ b/Source/equipment/potionkit-base.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const Resource = require('../../Classes/Resource.js');
+const { generateRandomNumber } = require('../../helpers.js');
 const { removeModifier } = require('../combatantDAO.js');
-const { rollConsumable } = require('../labyrinths/_labyrinthDictionary');
 
 module.exports = new EquipmentTemplate("Potion Kit", "Add 1 random potion to loot", "Instead add @{critBonus} potions", "Water", effect, ["Guarding Potion Kit", "Organic Potion Kit", "Urgent Potion Kit"])
 	.setCategory("Trinket")
@@ -10,12 +10,22 @@ module.exports = new EquipmentTemplate("Potion Kit", "Add 1 random potion to loo
 	.setCost(200)
 	.setUses(10);
 
+const rollablePotions = [
+	"Block Potion",
+	"Earthen Potion",
+	"Explosive Potion",
+	"Fiery Potion",
+	"Health Potion",
+	"Watery Potion",
+	"Windy Potion"
+];
+
 function effect(targets, user, isCrit, adventure) {
 	let { element, modifiers: [elementStagger], critBonus } = module.exports;
 	if (user.element === element) {
 		removeModifier(user, elementStagger);
 	}
-	const randomPotion = rollConsumable(adventure, "Potion");
+	const randomPotion = rollablePotions[generateRandomNumber(adventure, rollablePotions.length, "battle")];
 	if (isCrit) {
 		adventure.addResource(new Resource(randomPotion, "consumable", critBonus, "loot", 0));
 		return `${user.getName(adventure.room.enemyIdMap)} sets a double-batch of ${randomPotion} simmering.`;

--- a/Source/equipment/potionkit-guarding.js
+++ b/Source/equipment/potionkit-guarding.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const Resource = require('../../Classes/Resource.js');
+const { generateRandomNumber } = require('../../helpers.js');
 const { removeModifier, addBlock } = require('../combatantDAO.js');
-const { rollConsumable } = require('../labyrinths/_labyrinthDictionary');
 
 module.exports = new EquipmentTemplate("Guarding Potion Kit", "Gain @{block} block and add 1 random potion to loot", "Instead add @{critBonus} potions", "Water", effect, ["Organic Potion Kit", "Urgent Potion Kit"])
 	.setCategory("Trinket")
@@ -11,12 +11,22 @@ module.exports = new EquipmentTemplate("Guarding Potion Kit", "Gain @{block} blo
 	.setUses(10)
 	.setBlock(75);
 
+const rollablePotions = [
+	"Block Potion",
+	"Earthen Potion",
+	"Explosive Potion",
+	"Fiery Potion",
+	"Health Potion",
+	"Watery Potion",
+	"Windy Potion"
+];
+
 function effect(targets, user, isCrit, adventure) {
 	let { element, modifiers: [elementStagger], block, critBonus } = module.exports;
 	if (user.element === element) {
 		removeModifier(user, elementStagger);
 	}
-	const randomPotion = rollConsumable(adventure, "Potion");
+	const randomPotion = rollablePotions[generateRandomNumber(adventure, rollablePotions.length, "battle")];
 	addBlock(user, block);
 	if (isCrit) {
 		adventure.addResource(new Resource(randomPotion, "consumable", critBonus, "loot", 0));

--- a/Source/equipment/potionkit-organic.js
+++ b/Source/equipment/potionkit-organic.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const Resource = require('../../Classes/Resource.js');
+const { generateRandomNumber } = require('../../helpers.js');
 const { removeModifier } = require('../combatantDAO.js');
-const { rollConsumable } = require('../labyrinths/_labyrinthDictionary.js');
 
 module.exports = new EquipmentTemplate("Organic Potion Kit", "Add 1 random potion to loot, regain 1 durability when entering a new room", "Instead add @{critBonus} potions", "Water", effect, ["Guarding Potion Kit", "Urgent Potion Kit"])
 	.setCategory("Trinket")
@@ -10,12 +10,22 @@ module.exports = new EquipmentTemplate("Organic Potion Kit", "Add 1 random potio
 	.setCost(350)
 	.setUses(10);
 
+const rollablePotions = [
+	"Block Potion",
+	"Earthen Potion",
+	"Explosive Potion",
+	"Fiery Potion",
+	"Health Potion",
+	"Watery Potion",
+	"Windy Potion"
+];
+
 function effect(targets, user, isCrit, adventure) {
 	let { element, modifiers: [elementStagger], critBonus } = module.exports;
 	if (user.element === element) {
 		removeModifier(user, elementStagger);
 	}
-	const randomPotion = rollConsumable(adventure, "Potion");
+	const randomPotion = rollablePotions[generateRandomNumber(adventure, rollablePotions.length, "battle")];
 	if (isCrit) {
 		adventure.addResource(new Resource(randomPotion, "consumable", critBonus, "loot", 0));
 		return `${user.getName(adventure.room.enemyIdMap)} sets a double-batch of ${randomPotion} simmering.`;

--- a/Source/equipment/potionkit-urgent.js
+++ b/Source/equipment/potionkit-urgent.js
@@ -1,7 +1,7 @@
 const EquipmentTemplate = require('../../Classes/EquipmentTemplate.js');
 const Resource = require('../../Classes/Resource.js');
+const { generateRandomNumber } = require('../../helpers.js');
 const { removeModifier } = require('../combatantDAO.js');
-const { rollConsumable } = require('../labyrinths/_labyrinthDictionary');
 
 module.exports = new EquipmentTemplate("Urgent Potion Kit", "Add 1 random potion to loot with priority", "Instead add @{critBonus} potions", "Water", effect, ["Guarding Potion Kit", "Organic Potion Kit"])
 	.setCategory("Trinket")
@@ -11,12 +11,22 @@ module.exports = new EquipmentTemplate("Urgent Potion Kit", "Add 1 random potion
 	.setUses(10)
 	.setPriority(1);
 
+const rollablePotions = [
+	"Block Potion",
+	"Earthen Potion",
+	"Explosive Potion",
+	"Fiery Potion",
+	"Health Potion",
+	"Watery Potion",
+	"Windy Potion"
+];
+
 function effect(targets, user, isCrit, adventure) {
 	let { element, modifiers: [elementStagger], critBonus } = module.exports;
 	if (user.element === element) {
 		removeModifier(user, elementStagger);
 	}
-	const randomPotion = rollConsumable(adventure, "Potion");
+	const randomPotion = rollablePotions[generateRandomNumber(adventure, rollablePotions.length, "battle")];
 	if (isCrit) {
 		adventure.addResource(new Resource(randomPotion, "consumable", critBonus, "loot", 0));
 		return `${user.getName(adventure.room.enemyIdMap)} sets a double-batch of ${randomPotion} simmering.`;

--- a/Source/labyrinths/_labyrinthDictionary.js
+++ b/Source/labyrinths/_labyrinthDictionary.js
@@ -2,6 +2,8 @@ const { Adventure } = require("../../Classes/Adventure.js");
 const RoomTemplate = require("../../Classes/RoomTemplate.js");
 const { generateRandomNumber } = require("../../helpers.js");
 const { getRoom } = require("../Rooms/_roomDictionary.js");
+const { consumableExists } = require("../consumables/_consumablesDictionary.js");
+const { equipmentExists } = require("../equipment/_equipmentDictionary.js");
 
 const LABYRINTHS = {};
 
@@ -9,6 +11,31 @@ for (const file of [
 	"debugdungeon.js"
 ]) {
 	const labyrinth = require(`./${file}`);
+	for (const element in labyrinth.availableConsumables) {
+		for (const consumable of labyrinth.availableConsumables[element]) {
+			if (!consumableExists(consumable)) {
+				console.error(`Unregistered consumable name in ${labyrinth.name}: ${consumable}`);
+			}
+		}
+	}
+
+	for (const element in labyrinth.availableEquipment) {
+		for (const rarity in labyrinth.availableEquipment[element]) {
+			for (const equipment of labyrinth.availableEquipment[element][rarity]) {
+				if (!equipmentExists(equipment)) {
+					console.error(`Unregistered equipment name in ${labyrinth.name}: ${equipment}`);
+				}
+			}
+		}
+	}
+
+	for (const tag in labyrinth.availableRooms) {
+		for (const roomTitle of labyrinth.availableRooms[tag]) {
+			if (!getRoom(roomTitle)) {
+				console.error(`Unregistered room title in ${labyrinth.name}: ${roomTitle}`);
+			}
+		}
+	}
 	LABYRINTHS[labyrinth.name] = labyrinth;
 }
 
@@ -32,14 +59,10 @@ exports.getLabyrinthProperty = function (labyrinthName, propertyName) {
 
 /** Rolls a consumable's name from droppable consumables
  * @param {Adventure} adventure
- * @param {string} targetString
  * @returns {string}
  */
-exports.rollConsumable = function (adventure, targetString = "") {
-	const consumablePool = adventure.getElementPool().flatMap((element) => {
-		return LABYRINTHS[adventure.labyrinth].availableConsumables[element]
-			.filter(consumable => consumable.includes(targetString))
-	});
+exports.rollConsumable = function (adventure) {
+	const consumablePool = adventure.getElementPool().flatMap((element) => LABYRINTHS[adventure.labyrinth].availableConsumables[element]);
 
 	return consumablePool[generateRandomNumber(adventure, consumablePool.length, "general")];
 }


### PR DESCRIPTION
Summary
-------
- added entity validation for consumables, equipment, and rooms declared in labyrinths
   - moved rollable potion set definitions to equipment files
- removed "name filtering" functionality from `rollConsumable` (was only used by potion kits)

Local Tests Performed
---------------------
- [x] started up the bot, found unregistered "Piercing Lance" (was incorrectly named "Piercing Sword" in file)

Issue
-----
N/A