### PR TITLE
#625: crit calculation fixes

### DIFF
--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -285,7 +285,7 @@ exports.newRound = function (adventure, thread, lastRoundText) {
 			combatant.roundSpeed = Math.floor(combatant.speed * percentBonus);
 
 			// Roll Critical Hit
-			const baseCritChance = 0.25 + (combatant.critBonus / 100);
+			const baseCritChance = 0.25 * (1 + (combatant.critBonus / 100));
 			const max = 144;
 			let threshold = max * baseCritChance;
 			const featherCount = adventure.getArtifactCount("Hawk Tailfeather");

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -285,7 +285,7 @@ exports.newRound = function (adventure, thread, lastRoundText) {
 			combatant.roundSpeed = Math.floor(combatant.speed * percentBonus);
 
 			// Roll Critical Hit
-			const baseCritChance = 0.25 * (1 + (combatant.critBonus / 100));
+			const baseCritChance = (1 + (combatant.critBonus / 100)) * (1 / 4);
 			const max = 144;
 			let threshold = max * baseCritChance;
 			const featherCount = adventure.getArtifactCount("Hawk Tailfeather");

--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -285,16 +285,16 @@ exports.newRound = function (adventure, thread, lastRoundText) {
 			combatant.roundSpeed = Math.floor(combatant.speed * percentBonus);
 
 			// Roll Critical Hit
-			const baseCritChance = (1 + (combatant.critBonus / 100)) * (1 / 4) - 1;
+			const baseCritChance = 0.25 + (combatant.critBonus / 100);
 			const max = 144;
 			let threshold = max * baseCritChance;
-			if (combatant instanceof Delver) {
-				const featherCount = adventure.getArtifactCount("Hawk Tailfeather");
+			const featherCount = adventure.getArtifactCount("Hawk Tailfeather");
+			if (featherCount > 0 && combatant instanceof Delver) {
 				const featherCritChance = 1 - 0.85 ** featherCount;
 				threshold /= featherCritChance;
 				adventure.updateArtifactStat("Hawk Tailfeather", "Expected Extra Critical Hits", (threshold / max) - baseCritChance);
 			}
-			let critRoll = generateRandomNumber(adventure, max, "battle");
+			const critRoll = generateRandomNumber(adventure, max, "battle");
 			combatant.crit = critRoll < threshold;
 
 			// Roll Enemy Moves and Generate Dummy Moves


### PR DESCRIPTION
Summary
-------
- fix crit threshold ending up negative
- fix 0 Hawk Tailfeathers causing players to always crit

Local Tests Performed
---------------------
- [x] checked thresholds and rolled numbers in an adventure, they matched the predicted values

Issue
-----
Closes #625