### PR TITLE
#622: merchant fixes

### DIFF
--- a/Source/adventureDAO.js
+++ b/Source/adventureDAO.js
@@ -107,7 +107,7 @@ const roomTypesByRarity = {
 function rollGearTier(adventure) {
 	const cloverCount = adventure.getArtifactCount("Negative-One Leaf Clover");
 	const baseUpgradeChance = 1 / 8;
-	const cloverUpgradeChance = 1 - 0.80 ** cloverCount;
+	const cloverUpgradeChance = cloverCount > 0 ? 1 - 0.80 ** cloverCount : 1;
 	const max = 144;
 	const threshold = max * baseUpgradeChance / cloverUpgradeChance;
 	adventure.updateArtifactStat("Negative-One Leaf Clover", "Expected Extra Rare Equipment", (threshold / max) - baseUpgradeChance);

--- a/Source/roomDAO.js
+++ b/Source/roomDAO.js
@@ -318,7 +318,7 @@ function generateMerchantRows(adventure) {
 			let options = [];
 			categorizedResources[groupName].forEach((resource, i) => {
 				if (adventure.room.resources[resource].count > 0) {
-					const cost = getEquipmentProperty(resource, "cost");
+					const cost = adventure.room.resources[resource].cost;
 					const maxUses = getEquipmentProperty(resource, "maxUses");
 					let description = buildEquipmentDescription(resource, false);
 					if (description.length > 100) {


### PR DESCRIPTION
Summary
-------
- fix overpriced merchant selects showing wrong price
- fix party having 0 Negative-One Leaf Clovers to always upgrade merchant stock

Local Tests Performed
---------------------
- [x] checked for price/upgrades in merchant room in adventure

Issue
-----
Closes #622